### PR TITLE
Fix screenshot resolution if user selected a window with values identical to current spin box values.

### DIFF
--- a/src/screen_region.py
+++ b/src/screen_region.py
@@ -112,11 +112,11 @@ def selectWindow(self):
     rect = win32gui.GetClientRect(self.hwnd)
     self.rect.left = 8
     self.rect.top = 31
-    self.rect.right = 0 + rect[2]
-    self.rect.bottom = 0 + rect[3]
+    self.rect.right = 8 + rect[2]
+    self.rect.bottom = 31 + rect[3]
 
-    self.widthSpinBox.setValue(self.rect.right)
-    self.heightSpinBox.setValue(self.rect.bottom)
+    self.widthSpinBox.setValue(rect[2])
+    self.heightSpinBox.setValue(rect[3])
     self.xSpinBox.setValue(self.rect.left)
     self.ySpinBox.setValue(self.rect.top)
 


### PR DESCRIPTION
The old lines,     
`self.widthSpinBox.setValue(self.rect.right)`
`self.heightSpinBox.setValue(self.rect.bottom)`,
would not trigger `xSpinBox.valueChanged` (and then `updateX`) and `ySpinBox.valueChanged` (and then `updateY`) if the spin box values were the same as the selected window dimensions. This caused `self.rect.right` and `self.rect.bottom` to be 8 and 31 pixels short, respectively.

As far as I've been able to test, this has been rectified in lines 115-116, but that caused the spin box values to be set at incorrect values in lines 118-119. So I changed those accordingly.

Closes #58.