### PR TITLE
Fix numpad hotkey

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,14 @@
 {
   "recommendations": [
-    "ms-pyright.pyright",
+    "ms-python.vscode-pylance",
     "ms-python.python",
     "sonarsource.sonarlint-vscode",
-    "davidanson.vscode-markdownlint"
+    "davidanson.vscode-markdownlint",
+    "shardulm94.trailing-spaces",
+    "eamodio.gitlens"
+  ],
+  "unwantedRecommendations": [
+    "ms-pyright.pyright",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,13 +26,13 @@
       120,
     ]
   },
-  "//1": "Keeping autoformat to false for now to keep minimal changes",
+  // Keeping autoformat to false for now to keep minimal changes
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll": false,
   },
   "python.linting.pylintEnabled": false,
-  "//2": "Using flake8 as other linters are incomplete or have too many false positives last I tried",
+  // Using flake8 as other linters are incomplete or have too many false positives last I tried
   "python.linting.flake8Enabled": true,
   "python.linting.enabled": true,
   "python.linting.pycodestyleEnabled": false,
@@ -43,6 +43,11 @@
   "python.formatting.autopep8Args": [
     "--max-line-length=120"
   ],
-  "python.pythonPath": "",
   "files.insertFinalNewline": true,
+  "trailing-spaces.deleteModifiedLinesOnly": true,
+  "trailing-spaces.includeEmptyLines": true,
+  "trailing-spaces.trimOnSave": true,
+  "trailing-spaces.syntaxIgnore": [
+    "markdown"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This program compares split images to a capture region of any window (OBS, xspli
 ### Compatability
 - Windows 7 and 10.
 
+### Building
+- Read [requirements.txt](/requirements.txt) for information on how to run/build the python code
+
 ### Opening the program
 - Download the [latest version](https://github.com/austinryan/Auto-Split/releases)
 - Extract the file and open AutoSplit.exe.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ Pillow
 ImageHash
 pywin32
 keyboard
+pyautogui

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Requirements file for AutoSplit
+#
+# Python: CPython 3.7 (not 3.8 as there is no cp38 wheel for PyQt4)
+#
+# Usage: pip install -r requirements.txt
+#
+# Creating AutoSplit.exe with PyInstaller: pyinstaller -w -F src\AutoSplit.py
+#
+# You can find other wheels here: https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyqt4
+# If you use 32-bit installation of Python, use the the 2nd URL instead.
+https://download.lfd.uci.edu/pythonlibs/w4tscw6k/PyQt4-4.11.4-cp37-cp37m-win_amd64.whl
+# https://download.lfd.uci.edu/pythonlibs/w4tscw6k/PyQt4-4.11.4-cp37-cp37m-win32.whl
+#
+# Comment this out if you don't want to create AutoSplit.exe:
+PyInstaller
+#
+# Other dependencies:
+opencv-python
+Pillow
+ImageHash
+pywin32
+keyboard

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -6,15 +6,14 @@ import cv2
 import time
 import ctypes.wintypes
 import ctypes
-import keyboard
-import glob
 import numpy as np
 
+from hotkeys import send_hotkey
 import design
-import about
 import compare
 import capture_windows
 import split_parser
+
 
 class AutoSplit(QtGui.QMainWindow, design.Ui_MainWindow):
     from hotkeys import beforeSettingHotkey, afterSettingHotkey, setSplitHotkey, setResetHotkey, setSkipSplitHotkey, setUndoSplitHotkey, setPauseHotkey
@@ -530,7 +529,7 @@ class AutoSplit(QtGui.QMainWindow, design.Ui_MainWindow):
 
                     reset_similarity = self.compareImage(self.reset_image, self.reset_mask, capture)
                     if reset_similarity >= self.reset_image_threshold:
-                        keyboard.send(str(self.resetLineEdit.text()))
+                        send_hotkey(self.resetLineEdit.text())
                         self.reset()
 
                 # loop goes into here if start auto splitter text is "Start Auto Splitter"
@@ -637,7 +636,7 @@ class AutoSplit(QtGui.QMainWindow, design.Ui_MainWindow):
 
                             reset_similarity = self.compareImage(self.reset_image, self.reset_mask, capture)
                             if reset_similarity >= self.reset_image_threshold:
-                                keyboard.send(str(self.resetLineEdit.text()))
+                                send_hotkey(self.resetLineEdit.text())
                                 self.reset()
                                 continue
 
@@ -647,9 +646,9 @@ class AutoSplit(QtGui.QMainWindow, design.Ui_MainWindow):
 
                 # if {p} flag hit pause key, otherwise hit split hotkey
                 if (self.flags & 0x08 == 0x08):
-                    keyboard.send(str(self.pausehotkeyLineEdit.text()))
+                    send_hotkey(self.pausehotkeyLineEdit.text())
                 else:
-                    keyboard.send(str(self.splitLineEdit.text()))
+                    send_hotkey(self.splitLineEdit.text())
 
             # increase loop number if needed, set to 1 if it was the last loop.
             if self.loop_number < self.split_image_loop_amount[self.split_image_number]:
@@ -721,7 +720,7 @@ class AutoSplit(QtGui.QMainWindow, design.Ui_MainWindow):
 
                         reset_similarity = self.compareImage(self.reset_image, self.reset_mask, capture)
                         if reset_similarity >= self.reset_image_threshold:
-                            keyboard.send(str(self.resetLineEdit.text()))
+                            send_hotkey(self.resetLineEdit.text())
                             self.reset()
                             continue
 

--- a/src/hotkeys.py
+++ b/src/hotkeys.py
@@ -1,6 +1,7 @@
 import keyboard
 import threading
 
+
 # do all of these after you click "set hotkey" but before you type the hotkey.
 def beforeSettingHotkey(self):
     self.startautosplitterButton.setEnabled(False)
@@ -26,10 +27,71 @@ def afterSettingHotkey(self):
     self.setundosplithotkeyButton.setEnabled(True)
     self.setpausehotkeyButton.setEnabled(True)
 
-    return
 
-#--------------------HOTKEYS--------------------------
-#Going to comment on one func, and others will be similar.
+def is_digit(key):
+    try:
+        key_as_num = int(key)
+        return key_as_num >= 0 and key_as_num <= 9
+    except Exception:
+        return False
+
+
+def __validate_keypad(expected_key, keyboard_event):
+    # Prevent "num delete", "num dot" and "delete" from triggering each other
+    # as well as "dot" and "num dot"
+    if keyboard_event.scan_code == 83 or keyboard_event.scan_code == 52:
+        if expected_key == keyboard_event.name:
+            return True
+        else:
+            # TODO: "delete" won't work with "num delete" if localized in non-english
+            return False
+    # Prevent "action" from triggering "numpad" hotkeys
+    if is_digit(keyboard_event.name[-1]):
+        # Prevent "regular number" from activating "numpad" hotkeys
+        if expected_key.startswith("num "):
+            return keyboard_event.is_keypad
+        # Prevent "numpad" from activating "regular number" hotkeys
+        else:
+            return not keyboard_event.is_keypad
+    else:
+        # Prevent "num action" keys from triggering "regular number" and "numpad" hotkeys.
+        # Still allow the same key that might be localized differently on keypad vs non-keypad
+        return not is_digit(expected_key[-1])
+
+
+# NOTE: This is a workaround very specific to numpads.
+# Windows reports different physical keys with the same scan code.
+# For example, "Home", "Num Home" and "Num 7" are all "71".
+# See: https://github.com/boppreh/keyboard/issues/171#issuecomment-390437684
+#
+# We're doing the check here instead of saving the key code because it'll
+# cause issues with save files and the non-keypad shared keys are localized
+# while the keypad ones aren't.
+#
+# Since we reuse the key string we set to send to LiveSplit, we can't use fake names like "num home".
+# We're also trying to achieve the same hotkey behaviour as LiveSplit has.
+def _hotkey_action(keyboard_event, key_name, action):
+    if keyboard_event.event_type == keyboard.KEY_DOWN and __validate_keypad(key_name, keyboard_event):
+        action()
+
+
+def __get_key_name(keyboard_event):
+    return "num " + keyboard_event.name \
+        if keyboard_event.is_keypad and is_digit(keyboard_event.name) \
+        else keyboard_event.name
+
+
+def __is_key_already_set(self, key_name):
+    return key_name == self.splitLineEdit.text() \
+        or key_name == self.resetLineEdit.text() \
+        or key_name == self.skipsplitLineEdit.text() \
+        or key_name == self.undosplitLineEdit.text() \
+        or key_name == self.pausehotkeyLineEdit.text()
+
+
+# --------------------HOTKEYS--------------------------
+# TODO: Refactor to de-duplicate all this code, including settings_file.py
+# Going to comment on one func, and others will be similar.
 def setSplitHotkey(self):
     self.setsplithotkeyButton.setText('Press a key..')
 
@@ -38,48 +100,34 @@ def setSplitHotkey(self):
 
     # new thread points to callback. this thread is needed or GUI will freeze
     # while the program waits for user input on the hotkey
-    def callback():
+    def callback(hotkey):
         # try to remove the previously set hotkey if there is one.
         try:
-            keyboard.remove_hotkey(self.split_hotkey)
-        except AttributeError:
-            pass
-        #this error was coming up when loading the program and
-        #the lineEdit area was empty (no hotkey set), then you
-        #set one, reload the setting once back to blank works,
-        #but if you click reload settings again, it errors
-        #we can just have it pass, but don't want to throw in
-        #generic exception here in case another one of these
-        #pops up somewhere.
-        except KeyError:
+            keyboard.unhook_key(hotkey)
+        # KeyError was coming up when loading the program and
+        # the lineEdit area was empty (no hotkey set), then you
+        # set one, reload the setting once back to blank works,
+        # but if you click reload settings again, it errors
+        # we can just have it pass, but don't want to throw in
+        # generic exception here in case another one of these
+        # pops up somewhere.
+        except (AttributeError, KeyError):
             pass
 
         # wait until user presses the hotkey, then keyboard module reads the input
-        self.split_key = keyboard.read_hotkey(False)
-
-        # If the key the user presses is equal to itself or another hotkey already set,
-        # this causes issues. so here, it catches that, and will make no changes to the hotkey.
+        key_name = __get_key_name(keyboard.read_event(True))
         try:
-            if self.split_key == self.splitLineEdit.text() \
-                    or self.split_key == self.resetLineEdit.text() \
-                    or self.split_key == self.skipsplitLineEdit.text() \
-                    or self.split_key == self.undosplitLineEdit.text() \
-                    or self.split_key == self.pausehotkeyLineEdit.text():
-                self.split_hotkey = keyboard.add_hotkey(self.old_split_key, self.startAutoSplitter)
-                self.afterSettingHotkeySignal.emit()
-                return
-        except AttributeError:
-            self.afterSettingHotkeySignal.emit()
-            return
+            # If the key the user presses is equal to itself or another hotkey already set,
+            # this causes issues. so here, it catches that, and will make no changes to the hotkey.
 
-        # keyboard module allows you to hit multiple keys for a hotkey. they are joined
-        # together by +. If user hits two keys at the same time, make no changes to the
-        # hotkey. A try and except is needed if a hotkey hasn't been set yet. I'm not
-        # allowing for these multiple-key hotkeys because it can cause crashes, and
-        # not many people are going to really use or need this.
-        try:
-            if '+' in self.split_key:
-                self.split_hotkey = keyboard.add_hotkey(self.old_split_key, self.startAutoSplitter)
+            # or
+
+            # keyboard module allows you to hit multiple keys for a hotkey. they are joined
+            # together by +. If user hits two keys at the same time, make no changes to the
+            # hotkey. A try and except is needed if a hotkey hasn't been set yet. I'm not
+            # allowing for these multiple-key hotkeys because it can cause crashes, and
+            # not many people are going to really use or need this.
+            if __is_key_already_set(self, key_name) or '+' in key_name:
                 self.afterSettingHotkeySignal.emit()
                 return
         except AttributeError:
@@ -88,192 +136,131 @@ def setSplitHotkey(self):
 
         # add the key as the hotkey, set the text into the LineEdit, set it as old_xxx_key,
         # then emite a signal to re-enable some buttons and change some text in GUI.
-        self.split_hotkey = keyboard.add_hotkey(self.split_key, self.startAutoSplitter)
-        self.splitLineEdit.setText(self.split_key)
-        self.old_split_key = self.split_key
-        self.afterSettingHotkeySignal.emit()
-        return
 
-    t = threading.Thread(target=callback)
+        # We need to inspect the event to know if it comes from numpad because of _canonial_names.
+        # See: https://github.com/boppreh/keyboard/issues/161#issuecomment-386825737
+        # The best way to achieve this is make our own hotkey handling on top of hook
+        # See: https://github.com/boppreh/keyboard/issues/216#issuecomment-431999553
+        self.split_hotkey = keyboard.hook_key(key_name, lambda e: _hotkey_action(e, key_name, self.startAutoSplitter))
+        self.splitLineEdit.setText(key_name)
+        self.split_key = key_name
+        self.afterSettingHotkeySignal.emit()
+
+    t = threading.Thread(target=callback, args=(self.split_hotkey,))
     t.start()
-    return
+
 
 def setResetHotkey(self):
     self.setresethotkeyButton.setText('Press a key..')
     self.beforeSettingHotkey()
 
-    def callback():
+    def callback(hotkey):
         try:
-            keyboard.remove_hotkey(self.reset_hotkey)
-        except AttributeError:
+            keyboard.unhook_key(hotkey)
+        except (AttributeError, KeyError):
             pass
-        except KeyError:
-            pass
-        self.reset_key = keyboard.read_hotkey(False)
-        try:
-            if self.reset_key == self.splitLineEdit.text() \
-                    or self.reset_key == self.resetLineEdit.text() \
-                    or self.reset_key == self.skipsplitLineEdit.text() \
-                    or self.reset_key == self.undosplitLineEdit.text() \
-                    or self.reset_key == self.pausehotkeyLineEdit.text():
-                self.reset_hotkey = keyboard.add_hotkey(self.old_reset_key, self.startReset)
-                self.afterSettingHotkeySignal.emit()
-                return
-        except AttributeError:
-            self.afterSettingHotkeySignal.emit()
-            return
-        try:
-            if '+' in self.reset_key:
-                self.reset_hotkey = keyboard.add_hotkey(self.old_reset_key, self.startReset)
-                self.afterSettingHotkeySignal.emit()
-                return
-        except AttributeError:
-            self.afterSettingHotkeySignal.emit()
-            return
-        self.reset_hotkey = keyboard.add_hotkey(self.reset_key, self.startReset)
-        self.resetLineEdit.setText(self.reset_key)
-        self.old_reset_key = self.reset_key
-        self.afterSettingHotkeySignal.emit()
-        return
 
-    t = threading.Thread(target=callback)
+        key_name = __get_key_name(keyboard.read_event(True))
+
+        try:
+            if __is_key_already_set(self, key_name) or '+' in key_name:
+                self.afterSettingHotkeySignal.emit()
+                return
+        except AttributeError:
+            self.afterSettingHotkeySignal.emit()
+            return
+
+        self.reset_hotkey = keyboard.hook_key(key_name, lambda e: _hotkey_action(e, key_name, self.startReset))
+        self.resetLineEdit.setText(key_name)
+        self.reset_key = key_name
+        self.afterSettingHotkeySignal.emit()
+
+    t = threading.Thread(target=callback, args=(self.reset_hotkey,))
     t.start()
-    return
+
 
 def setSkipSplitHotkey(self):
     self.setskipsplithotkeyButton.setText('Press a key..')
     self.beforeSettingHotkey()
 
-    def callback():
+    def callback(hotkey):
         try:
-            keyboard.remove_hotkey(self.skip_split_hotkey)
-        except AttributeError:
-            pass
-        except KeyError:
+            keyboard.unhook_key(hotkey)
+        except (AttributeError, KeyError):
             pass
 
-        self.skip_split_key = keyboard.read_hotkey(False)
+        key_name = __get_key_name(keyboard.read_event(True))
 
         try:
-            if self.skip_split_key == self.splitLineEdit.text() \
-                    or self.skip_split_key == self.resetLineEdit.text() \
-                    or self.skip_split_key == self.skipsplitLineEdit.text() \
-                    or self.skip_split_key == self.undosplitLineEdit.text() \
-                    or self.skip_split_key == self.pausehotkeyLineEdit.text():
-                self.skip_split_hotkey = keyboard.add_hotkey(self.old_skip_split_key, self.startSkipSplit)
+            if __is_key_already_set(self, key_name) or '+' in key_name:
                 self.afterSettingHotkeySignal.emit()
                 return
         except AttributeError:
             self.afterSettingHotkeySignal.emit()
             return
 
-        try:
-            if '+' in self.skip_split_key:
-                self.skip_split_hotkey = keyboard.add_hotkey(self.old_skip_split_key, self.startSkipSplit)
-                self.afterSettingHotkeySignal.emit()
-                return
-        except AttributeError:
-            self.afterSettingHotkeySignal.emit()
-            return
-
-        self.skip_split_hotkey = keyboard.add_hotkey(self.skip_split_key, self.startSkipSplit)
-        self.skipsplitLineEdit.setText(self.skip_split_key)
-        self.old_skip_split_key = self.skip_split_key
+        self.skip_split_hotkey = keyboard.hook_key(key_name, lambda e: _hotkey_action(e, key_name, self.startSkipSplit))
+        self.skipsplitLineEdit.setText(key_name)
+        self.skip_split_key = key_name
         self.afterSettingHotkeySignal.emit()
-        return
 
-    t = threading.Thread(target=callback)
+    t = threading.Thread(target=callback, args=(self.skip_split_hotkey,))
     t.start()
-    return
+
 
 def setUndoSplitHotkey(self):
     self.setundosplithotkeyButton.setText('Press a key..')
     self.beforeSettingHotkey()
 
-    def callback():
+    def callback(hotkey):
         try:
-            keyboard.remove_hotkey(self.undo_split_hotkey)
-        except AttributeError:
-            pass
-        except KeyError:
+            keyboard.unhook_key(hotkey)
+        except (AttributeError, KeyError):
             pass
 
-        self.undo_split_key = keyboard.read_hotkey(False)
+        key_name = __get_key_name(keyboard.read_event(True))
 
         try:
-            if self.undo_split_key == self.splitLineEdit.text() \
-                    or self.undo_split_key == self.resetLineEdit.text() \
-                    or self.undo_split_key == self.skipsplitLineEdit.text() \
-                    or self.undo_split_key == self.undosplitLineEdit.text() \
-                    or self.undo_split_key == self.pausehotkeyLineEdit.text():
-                self.undo_split_hotkey = keyboard.add_hotkey(self.old_undo_split_key, self.startUndoSplit)
+            if __is_key_already_set(self, key_name) or '+' in key_name:
                 self.afterSettingHotkeySignal.emit()
                 return
         except AttributeError:
             self.afterSettingHotkeySignal.emit()
             return
 
-        try:
-            if '+' in self.undo_split_key:
-                self.undo_split_hotkey = keyboard.add_hotkey(self.old_undo_split_key, self.startUndoSplit)
-                self.afterSettingHotkeySignal.emit()
-                return
-        except AttributeError:
-            self.afterSettingHotkeySignal.emit()
-            return
-
-        self.undo_split_hotkey = keyboard.add_hotkey(self.undo_split_key, self.startUndoSplit)
-        self.undosplitLineEdit.setText(self.undo_split_key)
-        self.old_undo_split_key = self.undo_split_key
+        self.undo_split_hotkey = keyboard.hook_key(key_name, lambda e: _hotkey_action(e, key_name, self.startUndoSplit))
+        self.undosplitLineEdit.setText(key_name)
+        self.undo_split_key = key_name
         self.afterSettingHotkeySignal.emit()
-        return
 
-    t = threading.Thread(target=callback)
+    t = threading.Thread(target=callback, args=(self.undo_split_hotkey,))
     t.start()
-    return
+
 
 def setPauseHotkey(self):
     self.setpausehotkeyButton.setText('Press a key..')
     self.beforeSettingHotkey()
 
-    def callback():
+    def callback(hotkey):
         try:
-            keyboard.remove_hotkey(self.pause_hotkey)
-        except AttributeError:
-            pass
-        except KeyError:
+            keyboard.unhook_key(hotkey)
+        except (AttributeError, KeyError):
             pass
 
-        self.pause_key = keyboard.read_hotkey(False)
+        key_name = __get_key_name(keyboard.read_event(True))
 
         try:
-            if self.pause_key == self.splitLineEdit.text() \
-                    or self.pause_key == self.resetLineEdit.text() \
-                    or self.pause_key == self.skipsplitLineEdit.text() \
-                    or self.pause_key == self.undosplitLineEdit.text() \
-                    or self.pause_key == self.pausehotkeyLineEdit.text():
-                self.pause_hotkey = keyboard.add_hotkey(self.old_pause_key, self.startPause)
+            if __is_key_already_set(self, key_name) or '+' in key_name:
                 self.afterSettingHotkeySignal.emit()
                 return
         except AttributeError:
             self.afterSettingHotkeySignal.emit()
             return
 
-        try:
-            if '+' in self.pause_key:
-                self.pause_hotkey = keyboard.add_hotkey(self.old_pause_key, self.startPause)
-                self.afterSettingHotkeySignal.emit()
-                return
-        except AttributeError:
-            self.afterSettingHotkeySignal.emit()
-            return
-
-        self.pause_hotkey = keyboard.add_hotkey(self.pause_key, self.startPause)
-        self.pausehotkeyLineEdit.setText(self.pause_key)
-        self.old_pause_key = self.pause_key
+        self.pause_hotkey = keyboard.hook_key(key_name, lambda e: _hotkey_action(e, key_name, self.startPause))
+        self.pausehotkeyLineEdit.setText(key_name)
+        self.pause_key = key_name
         self.afterSettingHotkeySignal.emit()
-        return
 
-    t = threading.Thread(target=callback)
+    t = threading.Thread(target=callback, args=(self.pause_hotkey,))
     t.start()
-    return

--- a/src/settings_file.py
+++ b/src/settings_file.py
@@ -2,6 +2,7 @@ import keyboard
 import win32gui
 import pickle
 import glob
+import logging
 from PyQt4 import QtGui
 from hotkeys import _hotkey_action
 
@@ -108,7 +109,14 @@ def saveSettingsAs(self):
 
 
 def loadSettings(self):
-    if self.load_settings_on_open == True:
+    # hotkeys need to be initialized to be passed as thread arguments in hotkeys.py
+    self.split_hotkey = ""
+    self.reset_hotkey = ""
+    self.skip_split_hotkey = ""
+    self.undo_split_hotkey = ""
+    self.pause_hotkey = ""
+
+    if self.load_settings_on_open:
         self.settings_files = glob.glob("*.pkl")
         if len(self.settings_files) < 1:
             self.noSettingsFileOnOpenError()
@@ -173,12 +181,12 @@ def loadSettings(self):
         self.groupDummySplitsCheckBox.setChecked(self.group_dummy_splits_undo_skip_setting == 1)
         self.loopCheckBox.setChecked(self.loop_setting == 1)
         self.autostartonresetCheckBox.setChecked(self.auto_start_on_reset_setting == 1)
-        
+
         # TODO: Reuse code from hotkeys rather than duplicating here
         # try to set hotkeys from when user last closed the window
         try:
             keyboard.unhook_key(self.split_hotkey)
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass
         try:
             self.splitLineEdit.setText(str(self.split_key))
@@ -189,7 +197,7 @@ def loadSettings(self):
 
         try:
             keyboard.unhook_key(self.reset_hotkey)
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass
         try:
             self.resetLineEdit.setText(self.reset_key)
@@ -199,7 +207,7 @@ def loadSettings(self):
 
         try:
             keyboard.unhook_key(self.skip_split_hotkey)
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass
         try:
             self.skipsplitLineEdit.setText(self.skip_split_key)
@@ -209,7 +217,7 @@ def loadSettings(self):
 
         try:
             keyboard.unhook_key(self.undo_split_hotkey)
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass
         try:
             self.undosplitLineEdit.setText(self.undo_split_key)
@@ -219,7 +227,7 @@ def loadSettings(self):
 
         try:
             keyboard.unhook_key(self.pause_hotkey)
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass
         try:
             self.pausehotkeyLineEdit.setText(self.pause_key)
@@ -231,4 +239,5 @@ def loadSettings(self):
         self.checkLiveImage()
 
     except Exception:
+        logging.error(logging.traceback.format_exc())
         self.invalidSettingsError()

--- a/src/settings_file.py
+++ b/src/settings_file.py
@@ -3,6 +3,8 @@ import win32gui
 import pickle
 import glob
 from PyQt4 import QtGui
+from hotkeys import _hotkey_action
+
 
 def getSaveSettingsValues(self):
     # get values to be able to save settings
@@ -166,96 +168,63 @@ def loadSettings(self):
         self.hwnd = win32gui.FindWindow(None, self.hwnd_title)
 
         # set custom checkbox's accordingly
-        if self.custom_pause_times_setting == 1:
-            self.custompausetimesCheckBox.setChecked(True)
-        else:
-            self.custompausetimesCheckBox.setChecked(False)
-
-        if self.custom_thresholds_setting == 1:
-            self.customthresholdsCheckBox.setChecked(True)
-        else:
-            self.customthresholdsCheckBox.setChecked(False)
-
-        if self.group_dummy_splits_undo_skip_setting == 1:
-            self.groupDummySplitsCheckBox.setChecked(True)
-        else:
-            self.groupDummySplitsCheckBox.setChecked(False)
-
-        if self.loop_setting == 1:
-            self.loopCheckBox.setChecked(True)
-        else:
-            self.loopCheckBox.setChecked(False)
-
-        if self.auto_start_on_reset_setting == 1:
-            self.autostartonresetCheckBox.setChecked(True)
-        else:
-            self.autostartonresetCheckBox.setChecked(False)
-
+        self.custompausetimesCheckBox.setChecked(self.custom_pause_times_setting == 1)
+        self.customthresholdsCheckBox.setChecked(self.custom_thresholds_setting == 1)
+        self.groupDummySplitsCheckBox.setChecked(self.group_dummy_splits_undo_skip_setting == 1)
+        self.loopCheckBox.setChecked(self.loop_setting == 1)
+        self.autostartonresetCheckBox.setChecked(self.auto_start_on_reset_setting == 1)
+        
+        # TODO: Reuse code from hotkeys rather than duplicating here
         # try to set hotkeys from when user last closed the window
         try:
-            try:
-                keyboard.remove_hotkey(self.split_hotkey)
-            except AttributeError:
-                pass
+            keyboard.unhook_key(self.split_hotkey)
+        except AttributeError:
+            pass
+        try:
             self.splitLineEdit.setText(str(self.split_key))
-            self.split_hotkey = keyboard.add_hotkey(str(self.split_key), self.startAutoSplitter)
-            self.old_split_key = self.split_key
+            self.split_hotkey = keyboard.hook_key(str(self.split_key), lambda e: _hotkey_action(e, self.split_key, self.startAutoSplitter))
         # pass if the key is an empty string (hotkey was never set)
-        except ValueError:
-            pass
-        except KeyError:
+        except (ValueError, KeyError):
             pass
 
         try:
-            try:
-                keyboard.remove_hotkey(self.reset_hotkey)
-            except AttributeError:
-                pass
-            self.resetLineEdit.setText(str(self.reset_key))
-            self.reset_hotkey = keyboard.add_hotkey(str(self.reset_key), self.startReset)
-            self.old_reset_key = self.reset_key
-        except ValueError:
+            keyboard.unhook_key(self.reset_hotkey)
+        except AttributeError:
             pass
-        except KeyError:
+        try:
+            self.resetLineEdit.setText(self.reset_key)
+            self.reset_hotkey = keyboard.hook_key(self.reset_key, lambda e: _hotkey_action(e, self.reset_key, self.startReset))
+        except (ValueError, KeyError):
             pass
 
         try:
-            try:
-                keyboard.remove_hotkey(self.skip_split_hotkey)
-            except AttributeError:
-                pass
-            self.skipsplitLineEdit.setText(str(self.skip_split_key))
-            self.skip_split_hotkey = keyboard.add_hotkey(str(self.skip_split_key), self.startSkipSplit)
-            self.old_skip_split_key = self.skip_split_key
-        except ValueError:
+            keyboard.unhook_key(self.skip_split_hotkey)
+        except AttributeError:
             pass
-        except KeyError:
+        try:
+            self.skipsplitLineEdit.setText(self.skip_split_key)
+            self.skip_split_hotkey = keyboard.hook_key(self.skip_split_key, lambda e: _hotkey_action(e, self.skip_split_key, self.startSkipSplit))
+        except (ValueError, KeyError):
             pass
 
         try:
-            try:
-                keyboard.remove_hotkey(self.undo_split_hotkey)
-            except AttributeError:
-                pass
-            self.undosplitLineEdit.setText(str(self.undo_split_key))
-            self.undo_split_hotkey = keyboard.add_hotkey(str(self.undo_split_key), self.startUndoSplit)
-            self.old_undo_split_key = self.undo_split_key
-        except ValueError:
+            keyboard.unhook_key(self.undo_split_hotkey)
+        except AttributeError:
             pass
-        except KeyError:
+        try:
+            self.undosplitLineEdit.setText(self.undo_split_key)
+            self.undo_split_hotkey = keyboard.hook_key(self.undo_split_key, lambda e: _hotkey_action(e, self.undo_split_key, self.startUndoSplit))
+        except (ValueError, KeyError):
             pass
 
         try:
-            try:
-                keyboard.remove_hotkey(self.pause_hotkey)
-            except AttributeError:
-                pass
-            self.pausehotkeyLineEdit.setText(str(self.pause_key))
-            self.pause_hotkey = keyboard.add_hotkey(str(self.pause_key), self.startPause)
-            self.old_pause_key = self.pause_key
-        except ValueError:
+            keyboard.unhook_key(self.pause_hotkey)
+        except AttributeError:
             pass
-        except KeyError:
+        try:
+            self.pausehotkeyLineEdit.setText(self.pause_key)
+            self.pause_hotkey = keyboard.hook_key(self.pause_key, lambda e: _hotkey_action(e, self.pause_key, self.startPause))
+        except (ValueError, KeyError):
             pass
 
         self.last_successfully_loaded_settings_file_path = self.load_settings_file_path
@@ -263,4 +232,3 @@ def loadSettings(self):
 
     except Exception:
         self.invalidSettingsError()
-        pass


### PR DESCRIPTION
Fixed the numpad hotkeys by getting the key event instead of the name directly. Then checking if it's a keypad event and between [0, 9]. This is necessary because of `keyboard`'s use of `_canonial_names`. See: https://github.com/boppreh/keyboard/issues/161#issuecomment-386825737

I've refrained from changing too much here, but the hotkeys module really needs a good refactoring to reduce duplicate code.

![image](https://user-images.githubusercontent.com/1350584/115813695-a22ff680-a3c1-11eb-9810-dbbea28cb94c.png)

Fixes #8 
Fixes #25 