### PR TITLE
Capture hardware accelerated windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.ui]
+indent_size = 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
+# Distribution / packaging
+env/
+build/
+dist/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Dev settings
+*.pkl
+# Defaut settings
+!src/settings.pkl

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "ms-pyright.pyright",
+    "ms-python.python",
+    "sonarsource.sonarlint-vscode",
+    "davidanson.vscode-markdownlint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,48 @@
+{
+  "editor.rulers": [
+    80,
+    120
+  ],
+  "[git-commit]": {
+    "editor.rulers": [
+      72
+    ]
+  },
+  "editor.detectIndentation": false,
+  "editor.tabSize": 2,
+  "[python]": {
+    "editor.tabSize": 4,
+    "editor.rulers": [
+      72,
+      79,
+      120,
+    ]
+  },
+  "[py]": {
+    "editor.tabSize": 4,
+    "editor.rulers": [
+      72,
+      79,
+      120,
+    ]
+  },
+  "//1": "Keeping autoformat to false for now to keep minimal changes",
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": false,
+  },
+  "python.linting.pylintEnabled": false,
+  "//2": "Using flake8 as other linters are incomplete or have too many false positives last I tried",
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "python.linting.pycodestyleEnabled": false,
+  "python.linting.flake8Args": [
+    "--max-line-length=120"
+  ],
+  "python.linting.flake8CategorySeverity.F": "Warning",
+  "python.formatting.autopep8Args": [
+    "--max-line-length=120"
+  ],
+  "python.pythonPath": "",
+  "files.insertFinalNewline": true,
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This program compares split images to a capture region of any window (OBS, xspli
 ### Compatability
 - Windows 7 and 10.
 
+### Building
+- Read [requirements.txt](/requirements.txt) for information on how to run/build the python code
+
 ### Opening the program
 - Download the [latest version](https://github.com/austinryan/Auto-Split/releases)
 - Extract the file and open AutoSplit.exe.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Requirements file for AutoSplit
+#
+# Python: CPython 3.7 (not 3.8 as there is no cp38 wheel for PyQt4)
+#
+# Usage: pip install -r requirements.txt
+#
+# Creating AutoSplit.exe with PyInstaller: pyinstaller -w -F src\AutoSplit.py
+#
+# You can find other wheels here: https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyqt4
+# If you use 32-bit installation of Python, use the the 2nd URL instead.
+https://download.lfd.uci.edu/pythonlibs/w4tscw6k/PyQt4-4.11.4-cp37-cp37m-win_amd64.whl
+# https://download.lfd.uci.edu/pythonlibs/w4tscw6k/PyQt4-4.11.4-cp37-cp37m-win32.whl
+#
+# Comment this out if you don't want to create AutoSplit.exe:
+PyInstaller
+#
+# Other dependencies:
+opencv-python
+Pillow
+ImageHash
+pywin32
+keyboard

--- a/src/capture_windows.py
+++ b/src/capture_windows.py
@@ -1,11 +1,15 @@
-import numpy
-import cv2
-
+from ctypes import windll
+from ctypes.wintypes import LONG, RECT
+from win32 import win32gui
+import numpy as np
 import win32ui
-import win32gui
 import win32con
 
-def capture_region(hwnd, rect):
+# This is an undocumented nFlag value for PrintWindow
+PW_RENDERFULLCONTENT = 0x00000002
+
+
+def capture_region(hwnd: int, rect: RECT):
     """
     Captures an image of the region for a window matching the given
     parameters of the bounding box
@@ -14,25 +18,27 @@ def capture_region(hwnd, rect):
     @param rect: The coordinates of the region
     @return: The image of the region in the window in BGRA format
     """
-    
-    width = rect.right - rect.left
-    height = rect.bottom - rect.top
-   
-    wDC = win32gui.GetWindowDC(hwnd)
-    dcObj = win32ui.CreateDCFromHandle(wDC)
-    cDC = dcObj.CreateCompatibleDC()
+
+    width: LONG = rect.right - rect.left
+    height: LONG = rect.bottom - rect.top
+
+    windowDC = win32gui.GetWindowDC(hwnd)
+    dcObject = win32ui.CreateDCFromHandle(windowDC)
+    compatibleDC = dcObject.CreateCompatibleDC()
     bmp = win32ui.CreateBitmap()
-    bmp.CreateCompatibleBitmap(dcObj, width, height)
-    cDC.SelectObject(bmp)
-    cDC.BitBlt((0, 0), (width, height), dcObj, (rect.left, rect.top), win32con.SRCCOPY)
-   
-    img = bmp.GetBitmapBits(True)
-    img = numpy.frombuffer(img, dtype='uint8')
+    bmp.CreateCompatibleBitmap(dcObject, width, height)
+    compatibleDC.SelectObject(bmp)
+    compatibleDC.BitBlt((0, 0), (width, height), dcObject, (rect.left, rect.top), win32con.SRCCOPY)
+
+    # Force render full content through PrintWindow. Workaround to capture hardware accelerated windows
+    windll.user32.PrintWindow(hwnd, dcObject.GetSafeHdc(), PW_RENDERFULLCONTENT)
+
+    img: np._BufferType = np.frombuffer(bmp.GetBitmapBits(True), dtype='uint8')
     img.shape = (height, width, 4)
- 
-    dcObj.DeleteDC()
-    cDC.DeleteDC()
-    win32gui.ReleaseDC(hwnd, wDC)
+
+    dcObject.DeleteDC()
+    compatibleDC.DeleteDC()
+    win32gui.ReleaseDC(hwnd, windowDC)
     win32gui.DeleteObject(bmp.GetHandle())
-    
+
     return img


### PR DESCRIPTION
`windll.user32.PrintWindow(hwnd, dcObject.GetSafeHdc(), PW_RENDERFULLCONTENT)` is the 1 line fix. This is an undocumented feature of [PrintWindow](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-printwindow#parameters). 

Fixes the infamous SLOBS issue, as well as supposed windows 11 issues

![image](https://user-images.githubusercontent.com/1350584/140004325-02cf504a-b437-4685-afcb-19a2abc85277.png)
