### PR TITLE
check before PrintWindow

### DIFF
--- a/src/about.py
+++ b/src/about.py
@@ -59,7 +59,7 @@ class Ui_aboutAutoSplitWidget(object):
         aboutAutoSplitWidget.setWindowTitle(_translate("aboutAutoSplitWidget", "About AutoSplit", None))
         self.okButton.setText(_translate("aboutAutoSplitWidget", "OK", None))
         self.createdbyLabel.setText(_translate("aboutAutoSplitWidget", "<html><head/><body><p>Created by <a href=\"https://twitter.com/toufool\"><span style=\" text-decoration: underline; color:#0000ff;\">Toufool</span></a> and <a href=\"https://twitter.com/faschz\"><span style=\" text-decoration: underline; color:#0000ff;\">Faschz</span></a></p></body></html>", None))
-        self.versionLabel.setText(_translate("aboutAutoSplitWidget", "Version: 1.5.1", None))
+        self.versionLabel.setText(_translate("aboutAutoSplitWidget", "Version: 1.5.2", None))
         self.donatetextLabel.setText(_translate("aboutAutoSplitWidget", "If you enjoy using this program, please\n"
 "       consider donating. Thank you!", None))
         self.donatebuttonLabel.setText(_translate("aboutAutoSplitWidget", "<html><head/><body><p><a href=\"https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=BYRHQG69YRHBA&item_name=AutoSplit+development&currency_code=USD&source=url\"><img src=\":/resources/donatebutton.png\"/></p></body></html>", None))

--- a/src/capture_windows.py
+++ b/src/capture_windows.py
@@ -2,6 +2,7 @@ from ctypes import windll
 from ctypes.wintypes import LONG, RECT, HBITMAP
 from typing import Dict
 from win32 import win32gui
+import sys
 import numpy as np
 import win32ui
 import win32con
@@ -9,6 +10,7 @@ import win32con
 # This is an undocumented nFlag value for PrintWindow
 PW_RENDERFULLCONTENT = 0x00000002
 accelerated_windows: Dict[int, bool] = {}
+is_windows_11 = sys.getwindowsversion().build >= 22000
 
 
 def capture_region(hwnd: int, rect: RECT):
@@ -21,7 +23,9 @@ def capture_region(hwnd: int, rect: RECT):
     @return: The image of the region in the window in BGRA format
     """
 
-    is_accelerated_window = accelerated_windows.get(hwnd)
+    # Windows 11 has some jank, and we're not ready to fully investigate it
+    # for now let's ensure it works at the cost of performance
+    is_accelerated_window = is_windows_11 or accelerated_windows.get(hwnd)
 
     # The window type is not yet known, let's find out!
     if is_accelerated_window is None:
@@ -35,14 +39,14 @@ def capture_region(hwnd: int, rect: RECT):
     return __get_image(hwnd, rect, is_accelerated_window)
 
 
-def __get_image(hwnd: int, rect: RECT, printWindow=False):
+def __get_image(hwnd: int, rect: RECT, print_window=False):
     width: LONG = rect.right - rect.left
     height: LONG = rect.bottom - rect.top
     windowDC: int = win32gui.GetWindowDC(hwnd)
     dcObject = win32ui.CreateDCFromHandle(windowDC)
 
     # Causes a 10-15x performance drop. But allows recording hardware accelerated windows
-    if (printWindow):
+    if (print_window):
         windll.user32.PrintWindow(hwnd, dcObject.GetSafeHdc(), PW_RENDERFULLCONTENT)
 
     compatibleDC = dcObject.CreateCompatibleDC()

--- a/src/capture_windows.py
+++ b/src/capture_windows.py
@@ -3,6 +3,8 @@ from ctypes.wintypes import LONG, RECT, HBITMAP
 from typing import Dict
 from win32 import win32gui
 import sys
+from packaging import version
+import platform
 import numpy as np
 import win32ui
 import win32con
@@ -10,7 +12,7 @@ import win32con
 # This is an undocumented nFlag value for PrintWindow
 PW_RENDERFULLCONTENT = 0x00000002
 accelerated_windows: Dict[int, bool] = {}
-is_windows_11 = sys.getwindowsversion().build >= 22000
+is_windows_11 = version.parse(platform.version()) >= version.parse("10.0.22000")
 
 
 def capture_region(hwnd: int, rect: RECT):


### PR DESCRIPTION
Fixes #74
The logic goes as follows:
- If we already know whether a window needs PrintWindow to be called, no need to check
- In case we don't know yet (the check is only done once per new window). Check if the rendered image if fully black;
  - if so, PrintWindow needs to be called, and the image is obtained a second time
  - if not, just use the image we already obtained as it's perfectly valid