### PR TITLE
Better path and string manipulation

### DIFF
--- a/src/compare.py
+++ b/src/compare.py
@@ -55,7 +55,7 @@ def compare_l2_norm(source, capture):
     # The L2 Error is summed across all pixels, so this normalizes
     max_error = (source.size ** 0.5) * 255
 
-    return 1 - (error/max_error)
+    return 1 - (error / max_error)
 
 def compare_l2_norm_masked(source, capture, mask):
     """
@@ -93,7 +93,7 @@ def compare_template(source, capture):
     # that the value can be. Used for normalizing from 0 to 1.
     max_error = source.size * 255 * 255
 
-    return 1 - (min_val/max_error)
+    return 1 - (min_val / max_error)
 
 def compare_template_masked(source, capture, mask):
     """
@@ -129,7 +129,7 @@ def compare_phash(source, capture):
     source_hash = imagehash.phash(source)
     capture_hash = imagehash.phash(capture)
 
-    return 1 - ((source_hash - capture_hash)/64.0)
+    return 1 - ((source_hash - capture_hash) / 64.0)
 
 def compare_phash_masked(source, capture, mask):
     """
@@ -156,7 +156,7 @@ def compare_phash_masked(source, capture, mask):
     source_hash = imagehash.phash(source)
     capture_hash = imagehash.phash(capture)
 
-    return 1 - ((source_hash - capture_hash)/64.0)
+    return 1 - ((source_hash - capture_hash) / 64.0)
 
 
 def checkIfImageHasTransparency(image_path: str):

--- a/src/error_messages.py
+++ b/src/error_messages.py
@@ -18,7 +18,7 @@ def splitImageDirectoryNotFoundError():
 
 
 def imageTypeError(image):
-    setTextMessage('"' + image + '" is not a valid image file or the full image file path contains a special character.')
+    setTextMessage(f"\"{image}\" is not a valid image file or the full image file path contains a special character.")
 
 
 def regionError():

--- a/src/hotkeys.py
+++ b/src/hotkeys.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Union
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
 
@@ -36,7 +36,7 @@ def afterSettingHotkey(self: AutoSplit):
     self.setpausehotkeyButton.setEnabled(True)
 
 
-def is_digit(key):
+def is_digit(key: str):
     try:
         key_as_num = int(key)
         return key_as_num >= 0 and key_as_num <= 9
@@ -44,7 +44,7 @@ def is_digit(key):
         return False
 
 
-def send_command(self: AutoSplit, command):
+def send_command(self: AutoSplit, command: str):
     if self.is_auto_controlled:
         print(command, flush=True)
     else:
@@ -59,7 +59,7 @@ def send_command(self: AutoSplit, command):
 
 
 # Supports sending the appropriate scan code for all the special cases
-def _send_hotkey(key_or_scan_code):
+def _send_hotkey(key_or_scan_code: Union[int, str, Any]):
     if not key_or_scan_code:
         return
     hotkey_type = type(key_or_scan_code)
@@ -68,7 +68,7 @@ def _send_hotkey(key_or_scan_code):
     if hotkey_type is int:
         return keyboard.send(key_or_scan_code)
     elif hotkey_type is not str:
-        raise TypeError(f'key_or_scan_code "{key_or_scan_code}" {hotkey_type} should be an int or str')
+        raise TypeError(f'key_or_scan_code "{key_or_scan_code}" ({hotkey_type}) should be an int or str')
     if (not (key_or_scan_code.startswith('num ') or key_or_scan_code == 'decimal')):
         return keyboard.send(key_or_scan_code)
 
@@ -77,7 +77,7 @@ def _send_hotkey(key_or_scan_code):
     pyautogui.hotkey(key_or_scan_code.replace(' ', ''))
 
 
-def __validate_keypad(expected_key, keyboard_event):
+def __validate_keypad(expected_key: str, keyboard_event: keyboard.KeyboardEvent):
     # Prevent "(keypad)delete", "(keypad)./decimal" and "del" from triggering each other
     # as well as "." and "(keypad)./decimal"
     if keyboard_event.scan_code == 83 or keyboard_event.scan_code == 52:
@@ -111,18 +111,18 @@ def __validate_keypad(expected_key, keyboard_event):
 #
 # Since we reuse the key string we set to send to LiveSplit, we can't use fake names like "num home".
 # We're also trying to achieve the same hotkey behaviour as LiveSplit has.
-def _hotkey_action(keyboard_event, key_name, action):
+def _hotkey_action(keyboard_event: keyboard.KeyboardEvent, key_name: str, action):
     if keyboard_event.event_type == keyboard.KEY_DOWN and __validate_keypad(key_name, keyboard_event):
         action()
 
 
-def __get_key_name(keyboard_event):
+def __get_key_name(keyboard_event: keyboard.KeyboardEvent):
     return f"num {keyboard_event.name}"  \
         if keyboard_event.is_keypad and is_digit(keyboard_event.name) \
-        else keyboard_event.name
+        else str(keyboard_event.name)
 
 
-def __is_key_already_set(self: AutoSplit, key_name):
+def __is_key_already_set(self: AutoSplit, key_name: str):
     return key_name == self.splitLineEdit.text() \
         or key_name == self.resetLineEdit.text() \
         or key_name == self.skipsplitLineEdit.text() \

--- a/src/screen_region.py
+++ b/src/screen_region.py
@@ -133,11 +133,11 @@ def alignRegion(self: AutoSplit):
         return
     # This is the image used for aligning the capture region
     # to the best fit for the user.
-    template_filename = str(QtWidgets.QFileDialog.getOpenFileName(
+    template_filename = QtWidgets.QFileDialog.getOpenFileName(
         self,
         "Select Reference Image",
         "",
-        "Image Files (*.png *.jpg *.jpeg *.jpe *.jp2 *.bmp *.tiff *.tif *.dib *.webp *.pbm *.pgm *.ppm *.sr *.ras)"))
+        "Image Files (*.png *.jpg *.jpeg *.jpe *.jp2 *.bmp *.tiff *.tif *.dib *.webp *.pbm *.pgm *.ppm *.sr *.ras)")[0]
 
     # return if the user presses cancel
     if template_filename == '':


### PR DESCRIPTION
- Browse split folder button now opens the file selector from the parent of the currently selected folder
- Fixed align Region file selection crash
- Simplified auto_split_directory detection
- Unpolluted AutoSplit attributes of settings_files
- Simplified split_image_directory logic
- Proper path joining using os.path.join
- Removed extraneous string conversion (`str()`)
- Type hints in hotkeys.py
- Space around math divider