### PR TITLE
Fixed a few more crashes

### DIFF
--- a/src/error_messages.py
+++ b/src/error_messages.py
@@ -17,6 +17,10 @@ def splitImageDirectoryNotFoundError():
     setTextMessage("The Split Image Folder does not exist.")
 
 
+def splitImageDirectoryEmpty():
+    setTextMessage("The Split Image Folder is empty.")
+
+
 def imageTypeError(image):
     setTextMessage(f"\"{image}\" is not a valid image file or the full image file path contains a special character.")
 

--- a/src/screen_region.py
+++ b/src/screen_region.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
 
 from PyQt6 import QtCore, QtGui, QtTest, QtWidgets
 from win32 import win32gui
+import os
 import ctypes
 import ctypes.wintypes
 import cv2
@@ -209,6 +210,22 @@ def alignRegion(self: AutoSplit):
     self.ySpinBox.setValue(self.rect.top)
     self.widthSpinBox.setValue(best_width)
     self.heightSpinBox.setValue(best_height)
+
+
+def validateBeforeComparison(self: AutoSplit, show_error_condition: bool = True):
+    if not self.split_image_directory:
+        error = error_messages.splitImageDirectoryError
+    elif not os.path.isdir(self.split_image_directory):
+        error = error_messages.splitImageDirectoryNotFoundError
+    elif not os.listdir(self.split_image_directory):
+        error = error_messages.splitImageDirectoryEmpty
+    elif self.hwnd == 0 or win32gui.GetWindowText(self.hwnd) == '':
+        error = error_messages.regionError
+    elif self.width == 0 or self.height == 0:
+        error = error_messages.regionSizeError
+    if error and show_error_condition:
+        error()
+    return not error
 
 
 # widget to select a window and obtain its bounds

--- a/src/settings_file.py
+++ b/src/settings_file.py
@@ -24,7 +24,6 @@ def getSaveSettingsValues(self: AutoSplit):
     self.y = self.ySpinBox.value()
     self.width = self.widthSpinBox.value()
     self.height = self.heightSpinBox.value()
-    self.split_image_directory = self.splitimagefolderLineEdit.text()
     self.similarity_threshold = self.similaritythresholdDoubleSpinBox.value()
     self.comparison_index = self.comparisonmethodComboBox.currentIndex()
     self.pause = self.pauseDoubleSpinBox.value()


### PR DESCRIPTION
- [New] Fixed empty splits directory crashes
- [New] Check if folder path is actually a folder
- Fixed missing attribute self.split_image_directory
- Browse folder fallback to auto_split_directory if self.split_image_directory was previously empty
- Use self.split_image_directory instead of self.splitimagefolderLineEdit.text()
- Reduced duplicated code from checks before comparisons
- Read images only once in checkFPS
- Initialize attributes BEFORE loading settings