### PR TITLE
Make Save Settings more intuitive

### DIFF
--- a/src/AutoControlledWorker.py
+++ b/src/AutoControlledWorker.py
@@ -35,8 +35,7 @@ class AutoControlledWorker(QtCore.QObject):
                 self.autosplit.reset_signal.emit()
             elif line.startswith("settings"):
                 # Allow for any split character between "settings" and the path
-                self.autosplit.load_settings_file_path = line[9:]
-                settings.load_settings(self.autosplit, load_settings_from_livesplit=True)
+                settings.load_settings(self.autosplit, line[9:])
             # TODO: Not yet implemented in AutoSplit Integration
             # elif line == 'pause':
             #     self.pause_signal.emit()


### PR DESCRIPTION
- Don't close if user has cancelled "saving sattings as"
- Don't update last_successfully_loaded_settings_file_path if load was not successful
- "Save Settings As" defaults to the last_successfully_loaded_settings_file_path THEN the .exe
- When closing app, use save_settings instead of save_settings_as

.
- Removed more attributes from AutoSplit class