### PR TITLE
Batch of updates and fixes for 2.0.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,11 +11,8 @@ ignore=
   SIM105, ; contextlib.suppress is roughly 3x slower than try/except
   CCE001, ; False positives for attribute docstrings
 per-file-ignores=
-    ; Docstrings in type stubs
-    ; Function bodys contain other than just ... (eg: raise)
-    ; Single quote docstrings
-    typings/cv2-stubs/__init__.pyi: Q000,E704,E501,N8,A001,A002,A003,CCE002,F401, Y021,Y010,Q002
     ; Quotes
+    ; Allow ... on same line as class
     ; Allow ... on same line as def
     ; Line too long
     ; Naming conventions can't be controlled for external libraries
@@ -24,7 +21,8 @@ per-file-ignores=
     ; Attribute names can't be controlled for external libraries
     ; False positive Class level expression with elipsis
     ; Type re-exports
-    *.pyi:                          Q000,E704,E501,N8,A001,A002,A003,CCE002,F401
+    ; mypy 3.7 Union issue
+    *.pyi:                          Q000,E701,E704,E501,N8,A001,A002,A003,CCE002,F401,Y037
 ; PyQt methods
 ignore-names=closeEvent,paintEvent,keyPressEvent,mousePressEvent,mouseMoveEvent,mouseReleaseEvent
 ; McCabe max-complexity is also taken care of by Pylint and doesn't fail the build there

--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,7 @@ max-line-length=120
 exclude=src/gen/, typings/cv2-stubs/__init__.pyi
 ignore=
   W503,   ; Linebreak before binary operator
+  E124,   ; Closing bracket may not match multi-line method invocation style (enforced by add-trailing-comma)
   E402,   ; Allow imports at the bottom of file
   Y026,   ; Not using typing_extensions
   SIM105, ; contextlib.suppress is roughly 3x slower than try/except

--- a/.flake8
+++ b/.flake8
@@ -22,7 +22,7 @@ per-file-ignores=
     ; False positive Class level expression with elipsis
     ; Type re-exports
     ; mypy 3.7 Union issue
-    *.pyi:                          Q000,E701,E704,E501,N8,A001,A002,A003,CCE002,F401,Y037
+    *.pyi: Q000,E701,E704,E501,N8,A001,A002,A003,CCE002,F401,Y037
 ; PyQt methods
 ignore-names=closeEvent,paintEvent,keyPressEvent,mousePressEvent,mouseMoveEvent,mouseReleaseEvent
 ; McCabe max-complexity is also taken care of by Pylint and doesn't fail the build there

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
+      # Pyright is version and platform sensible
       matrix:
         python-version: ["3.9", "3.10"]
     steps:
@@ -68,6 +69,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
+      # Pylint is version and platform sensible
       matrix:
         python-version: ["3.9", "3.10"]
     steps:
@@ -87,6 +89,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
+      # Flake8 is tied to the version of Python on which it runs. Platform checks are ignored
       matrix:
         python-version: ["3.9", "3.10"]
     steps:
@@ -103,6 +106,7 @@ jobs:
       - name: Analysing the code with Flake8
         run: flake8 src/ typings/
   Bandit:
+    # Bandit only matters on the version deployed. Platform checks are ignored
     runs-on: windows-latest
     steps:
       - name: Checkout ${{ github.repository }}/${{ github.ref }}
@@ -121,6 +125,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
+      # Only the Python version we plan on shipping matters.
       matrix:
         python-version: ["3.10"]
     steps:

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -53,8 +53,6 @@ jobs:
     steps:
       - name: Checkout ${{ github.repository }}/${{ github.ref }}
         uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -64,7 +62,10 @@ jobs:
       - run: scripts/install.ps1
         shell: pwsh
       - name: Analysing the code with Pyright
-        run: pyright src/ --warnings
+        uses: jakebailey/pyright-action@v1
+        with:
+          working-directory: src/
+          extra-args: --warnings
   Pylint:
     runs-on: windows-latest
     strategy:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,10 @@
     "bungcip.better-toml",
     "davidanson.vscode-markdownlint",
     "eamodio.gitlens",
+    "emeraldwalk.runonsave",
+    "ms-python.autopep8",
     "ms-python.flake8",
+    "ms-python.isort",
     "ms-python.pylint",
     "ms-python.python",
     "ms-python.vscode-pylance",
@@ -18,6 +21,8 @@
     // Must disable in this workspace //
     // https://github.com/microsoft/vscode/issues/40239 //
     //
+    // We use autopep8
+    "ms-python.black-formatter",
     // VSCode has implemented an optimized version
     "coenraads.bracket-pair-colorizer",
     "coenraads.bracket-pair-colorizer-2",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,11 +26,11 @@
   "emeraldwalk.runonsave": {
     "commands": [
       {
-        "match": "\\.py",
+        "match": "\\.pyi?",
         "cmd": "unify ${file} --in-place --quote=\"\\\"\""
       },
       {
-        "match": "\\.py",
+        "match": "\\.pyi?",
         "cmd": "add-trailing-comma ${file} --py36-plus"
       },
     ]
@@ -70,6 +70,7 @@
       120, // Our hard rule
     ],
   },
+  "python.formatting.provider": "autopep8",
   "python.analysis.diagnosticMode": "workspace",
   "python.linting.enabled": true,
   // Use the new Pylint extension instead

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,18 @@
   "trailing-spaces.syntaxIgnore": [
     "markdown"
   ],
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "\\.py",
+        "cmd": "unify ${file} --in-place --quote=\"\\\"\""
+      },
+      {
+        "match": "\\.py",
+        "cmd": "add-trailing-comma ${file} --py36-plus"
+      },
+    ]
+  },
   "files.associations": {
     "*.json": "json",
     "extensions.json": "jsonc",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,12 +47,14 @@
     "*.lock": true,
   },
   "[python]": {
+    // Cannot use autotpep8 until https://github.com/microsoft/vscode-autopep8/issues/32 is fixed
+    "editor.defaultFormatter": "ms-python.python",
     "editor.tabSize": 4,
     "editor.rulers": [
       72, // PEP8-17 docstrings
       // 79, // PEP8-17 default max
       // 88, // Black default
-      99, // PEP8-17 acceptable max
+      // 99, // PEP8-17 acceptable max
       120, // Our hard rule
     ],
   },
@@ -115,6 +117,7 @@
   "powershell.codeFormatting.useCorrectCasing": true,
   "powershell.codeFormatting.whitespaceBetweenParameters": true,
   "powershell.integratedConsole.showOnStartup": false,
+  "terminal.integrated.defaultProfile.windows": "PowerShell",
   "xml.codeLens.enabled": true,
   "xml.format.spaceBeforeEmptyCloseTag": false,
 }

--- a/README.md
+++ b/README.md
@@ -27,17 +27,8 @@ This program can be used to automatically start, split, and reset your preferred
 
 ### Building
 
-(This is not required for normal use)
-
-- Python 3.9 - 3.10.
-- Microsoft Visual C++ 14.0 or greater may be required to build the executable. Get it with [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
-
-- Read [requirements.txt](/scripts/requirements.txt) for more information on how to install, run and build the python code.
-  - Run `./scripts/install.ps1` to install all dependencies.
-  - Run the app directly with `./scripts/start.ps1 [--auto-controlled]`.
-  - Run `./scripts/build.ps1` to build an executable.
-- Recompile resources after modifications by running `./scripts/compile_resources.ps1`.
-- All configured for VSCode, including Run (F5) and Build (Ctrl+Shift+B) commands.
+(This is not required for normal use)  
+Refer to the [build instructions](build%20instructions.md) if you'd like to build the application yourself or run it directly in Python.
 
 ## OPTIONS
 
@@ -225,7 +216,7 @@ The AutoSplit LiveSplit Component will directly connect AutoSplit with LiveSplit
 - Place the .dll file into your `[...]\LiveSplit\Components` folder.
 - Open LiveSplit -> Right Click -> Edit Layout -> Plus Button -> Control -> AutoSplit Integration.
 - Click Layout Settings -> AutoSplit Integration
-- Click the Browse buttons to locate your AutoSplit Path (path to AutoSplit.exe) and Profile Path (path to your AutoSplit `.toml` profile file) respectively.
+- Click the Browse buttons to locate your AutoSplit Path (path to AutoSplit executable) and Profile Path (path to your AutoSplit `.toml` profile file) respectively.
   - If you have not yet set saved a profile, you can do so using AutoSplit, and then go back and set your Settings Path.
 - Once set, click OK, and then OK again to close the Layout Editor. Right click LiveSplit -> Save Layout to save your layout. AutoSplit and your selected profile will now open automatically when opening that LiveSplit Layout `.lsl` file.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This program can be used to automatically start, split, and reset your preferred
 - There are three comparison methods to choose from: L2 Norm, Histograms, and Perceptual Hash (or pHash).
   - L2 Norm: This method should be fine to use for most cases. It finds the difference between each pixel, squares it, sums it over the entire image and takes the square root. This is very fast but is a problem if your image is high frequency. Any translational movement or rotation can cause similarity to be very different.
   - Histograms: An explanation on Histograms comparison can be found [here](https://mpatacchiola.github.io/blog/2016/11/12/the-simplest-classifier-histogram-intersection.html). This is a great method to use if you are using several masked images.
+    > This algorithm is particular reliable when the colour is a strong predictor of the object identity. The histogram intersection [...] is robust to occluding objects in the foreground.
   - Perceptual Hash: An explanation on pHash comparison can be found [here](http://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html). It is highly recommended to NOT use pHash if you use masked images. It is very inaccurate.
 
 #### Capture Method

--- a/build instructions.md
+++ b/build instructions.md
@@ -1,0 +1,24 @@
+# Install and Build instructions
+
+## Requirements
+
+### Windows
+
+- Microsoft Visual C++ 14.0 or greater may be required to build the executable. Get it with [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).  
+
+### All platforms
+
+- [Python](https://www.python.org/downloads/) 3.9+.
+- [Node](https://nodejs.org) is optional, but required for complete linting. Should be installed automatically.
+- [VSCode](https://code.visualstudio.com/Download) is not required, but highly recommended.
+  - Everything already configured in the workspace, including Run (F5) and Build (Ctrl+Shift+B) commands, default shell, and recommended extensions.
+  - [PyCharm](https://www.jetbrains.com/pycharm/) is also a good Python IDE, but nothing is configured. If you are a PyCharm user, feel free to open a PR with all necessary workspace configurations!
+
+## Install and Build steps
+
+- Read [requirements.txt](/scripts/requirements.txt) for more information on how to install, run and build the python code.
+  - Run `./scripts/install.ps1` to install all dependencies.
+  - Run the app directly with `./scripts/start.ps1 [--auto-controlled]`.
+    - Or debug by pressing `F5` in VSCode
+  - Run `./scripts/build.ps1` or press `CTRL+Shift+B` in VSCode to build an executable.
+- Recompile resources after modifications by running `./scripts/compile_resources.ps1`.

--- a/build instructions.md
+++ b/build instructions.md
@@ -9,7 +9,8 @@
 ### All platforms
 
 - [Python](https://www.python.org/downloads/) 3.9+.
-- [Node](https://nodejs.org) is optional, but required for complete linting. Should be installed automatically.
+- [Node](https://nodejs.org) is optional, but required for complete linting.
+  - Alternatively you can install the [pyright python wrapper](https://pypi.org/project/pyright/) which has a bit of an overhead delay.
 - [VSCode](https://code.visualstudio.com/Download) is not required, but highly recommended.
   - Everything already configured in the workspace, including Run (F5) and Build (Ctrl+Shift+B) commands, default shell, and recommended extensions.
   - [PyCharm](https://www.jetbrains.com/pycharm/) is also a good Python IDE, but nothing is configured. If you are a PyCharm user, feel free to open a PR with all necessary workspace configurations!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://github.com/hhatto/autopep8#more-advanced-usage
 [tool.autopep8]
 max_line_length = 120
-# recursive = true
+recursive = true
 aggressive = 3
 ignore = [
   "E124", # Closing bracket may not match multi-line method invocation style (enforced by add-trailing-comma)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,12 @@
 # https://github.com/hhatto/autopep8#more-advanced-usage
 [tool.autopep8]
 max_line_length = 120
-recursive = true
+# recursive = true
 aggressive = 3
-ignore = ["E70"] # Allow ... on same line as def
+ignore = [
+  "E124", # Closing bracket may not match multi-line method invocation style (enforced by add-trailing-comma)
+  "E70" # Allow ... on same line as def
+]
 
 
 # https://github.com/microsoft/pyright/blob/main/docs/configuration.md#sample-pyprojecttoml-file
@@ -105,13 +108,6 @@ max-branches = 15
 valid-classmethod-first-arg = "self"
 # https://pylint.pycqa.org/en/latest/user_guide/options.html#naming-styles
 module-naming-style = "any"
-# Can't make private class with PascalCase
-class-rgx = "_?_?[a-zA-Z]+?$"
-good-names = [
-  # PyQt methods
-  "closeEvent", "paintEvent", "keyPressEvent", "mousePressEvent", "mouseMoveEvent", "mouseReleaseEvent",
-  # https://github.com/PyCQA/pylint/issues/2018
-  "id", "x", "y", "a0", "i", "t0", "t1"]
 disable = [
   # No need to mention the fixmes
   "fixme",
@@ -121,6 +117,8 @@ disable = [
   "unused-import",
   "wrong-import-order",
   "wrong-import-position",
+  # Already taken care of by Flake8-naming, which does a better job
+  "invalid-name",
   # Already taken care of and grayed out. Also conflicts with Pylance reportIncompatibleMethodOverride
   "unused-argument",
   # Only reports a single instance. Pyright does a better job anyway

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,12 @@ ignore = [
 [tool.pyright]
 typeCheckingMode = "strict"
 # Extra strict
-reportImplicitStringConcatenation="error"
-reportCallInDefaultInitializer="error"
-reportMissingSuperCall="none" # False positives on base classes
-reportPropertyTypeMismatch="error"
-reportUninitializedInstanceVariable="error"
-reportUnnecessaryTypeIgnoreComment="error"
+reportImplicitStringConcatenation = "error"
+reportCallInDefaultInitializer = "error"
+reportMissingSuperCall = "none" # False positives on base classes
+reportPropertyTypeMismatch = "error"
+reportUninitializedInstanceVariable = "error"
+reportUnnecessaryTypeIgnoreComment = "error"
 # Exclude from scanning when running pyright
 exclude = [
   # Auto generated, produces unecessary `# type: ignore`
@@ -30,7 +30,7 @@ ignore = [
   # We expect stub files to be incomplete or contain useless statements
   "**/*.pyi",
 ]
-reportUnusedCallResult="none"
+reportUnusedCallResult = "none"
 # Type stubs may not be completable
 reportMissingTypeStubs = "warning"
 # False positives with TYPE_CHECKING

--- a/res/about.ui
+++ b/res/about.ui
@@ -103,7 +103,7 @@ Thank you!</string>
     </rect>
    </property>
    <property name="text">
-    <string/>
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.paypal.com/cgi-bin/webscr?cmd=_donations&amp;amp;business=BYRHQG69YRHBA&amp;amp;item_name=AutoSplit+development&amp;amp;currency_code=USD&amp;amp;source=url&quot;&gt;&lt;img src=&quot;:/resources/btn_donateCC_LG.png&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
    <property name="pixmap">
     <pixmap resource="resources.qrc">:/resources/btn_donateCC_LG.png</pixmap>

--- a/res/about.ui
+++ b/res/about.ui
@@ -32,7 +32,9 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">
-    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
+    <normaloff>:/resources/icon.ico</normaloff>
+    :/resources/icon.ico
+   </iconset>
   </property>
   <widget class="QPushButton" name="ok_button">
    <property name="geometry">

--- a/res/design.ui
+++ b/res/design.ui
@@ -40,10 +40,10 @@
    <widget class="QLabel" name="x_label">
     <property name="geometry">
      <rect>
-      <x>30</x>
+      <x>11</x>
       <y>143</y>
-      <width>7</width>
-      <height>16</height>
+      <width>44</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
@@ -240,10 +240,10 @@
    <widget class="QLabel" name="width_label">
     <property name="geometry">
      <rect>
-      <x>17</x>
+      <x>11</x>
       <y>183</y>
-      <width>33</width>
-      <height>16</height>
+      <width>44</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
@@ -256,10 +256,10 @@
    <widget class="QLabel" name="height_label">
     <property name="geometry">
      <rect>
-      <x>70</x>
+      <x>66</x>
       <y>183</y>
-      <width>41</width>
-      <height>16</height>
+      <width>44</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
@@ -427,10 +427,10 @@
    <widget class="QLabel" name="y_label">
     <property name="geometry">
      <rect>
-      <x>85</x>
+      <x>66</x>
       <y>143</y>
-      <width>7</width>
-      <height>16</height>
+      <width>44</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">

--- a/res/design.ui
+++ b/res/design.ui
@@ -32,7 +32,9 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">
-    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
+    <normaloff>:/resources/icon.ico</normaloff>
+    :/resources/icon.ico
+   </iconset>
   </property>
   <widget class="QWidget" name="central_widget">
    <widget class="QLabel" name="x_label">
@@ -46,6 +48,9 @@
     </property>
     <property name="text">
      <string>X</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
     </property>
    </widget>
    <widget class="QPushButton" name="select_region_button">
@@ -244,6 +249,9 @@
     <property name="text">
      <string>Width</string>
     </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
    </widget>
    <widget class="QLabel" name="height_label">
     <property name="geometry">
@@ -256,6 +264,9 @@
     </property>
     <property name="text">
      <string>Height</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
     </property>
    </widget>
    <widget class="QLabel" name="fps_value_label">
@@ -424,6 +435,9 @@
     </property>
     <property name="text">
      <string>Y</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
     </property>
    </widget>
    <widget class="QPushButton" name="align_region_button">

--- a/res/settings.ui
+++ b/res/settings.ui
@@ -32,7 +32,9 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
+    <normaloff>:/resources/icon.ico</normaloff>
+    :/resources/icon.ico
+   </iconset>
   </property>
   <widget class="QGroupBox" name="capture_settings_groupbox">
    <property name="geometry">

--- a/res/settings.ui
+++ b/res/settings.ui
@@ -200,6 +200,8 @@ Histograms:
 An explanation on Histograms comparison can be found here
 https://mpatacchiola.github.io/blog/2016/11/12/the-simplest-classifier-histogram-intersection.html
 This is a great method to use if you are using several masked images.
+> This algorithm is particular reliable when the colour is a strong predictor of the object identity.
+> The histogram intersection [...] is robust to occluding objects in the foreground.
 
 Perceptual Hash:
 An explanation on pHash comparison can be found here

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -7,4 +7,4 @@ $arguments = @(
   '--icon=res/icon.ico',
   '--splash=res/splash.png')
 
-pyinstaller $arguments "$PSScriptRoot/../src/AutoSplit.py"
+Start-Process pyinstaller -Wait -ArgumentList "$arguments `"$PSScriptRoot/../src/AutoSplit.py`""

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,8 +1,10 @@
 & "$PSScriptRoot/compile_resources.ps1"
-pyinstaller `
-  --onefile `
-  --windowed `
-  --additional-hooks-dir=Pyinstaller/hooks `
-  --icon=res/icon.ico `
-  --splash=res/splash.png `
-  "$PSScriptRoot/../src/AutoSplit.py"
+
+$arguments = @(
+  '--onefile',
+  '--windowed',
+  '--additional-hooks-dir=Pyinstaller/hooks',
+  '--icon=res/icon.ico',
+  '--splash=res/splash.png')
+
+pyinstaller $arguments "$PSScriptRoot/../src/AutoSplit.py"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,7 +9,10 @@ If ($IsWindows) {
 $dev = If ($env:GITHUB_JOB -eq 'Build') { '' } Else { '-dev' }
 # Ensures installation tools are up to date. This also aliases pip to pip3 on MacOS.
 python3 -m pip install wheel pip setuptools --upgrade
-pip install -r "$PSScriptRoot/requirements$dev.txt"
+pip install -r "$PSScriptRoot/requirements$dev.txt" --upgrade
+if (Get-Command 'npm' -ErrorAction SilentlyContinue) {
+  npm i --global pyright@latest
+}
 
 # Don't compile resources on the Build CI job as it'll do so in build script
 If ($dev) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,9 +7,9 @@ If ($IsWindows) {
 
 # Installing Python dependencies
 $dev = If ($env:GITHUB_JOB -eq 'Build') { '' } Else { '-dev' }
-# Ensures installation tools are up to date.
+# Ensures installation tools are up to date. This also aliases pip to pip3 on MacOS.
 python3 -m pip install wheel pip setuptools --upgrade
-python3 -m pip install -r "$PSScriptRoot/requirements$dev.txt"
+pip install -r "$PSScriptRoot/requirements$dev.txt"
 
 # Don't compile resources on the Build CI job as it'll do so in build script
 If ($dev) {

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -5,7 +5,7 @@ $exitCodes = 0
 Write-Host "`nRunning autofixes..."
 isort src/ typings/
 autopep8 $(git ls-files '**.py*') --in-place
-unify src/ --recursive --in-place --quote='"""'
+unify src/ --recursive --in-place --quote='"'
 add-trailing-comma $(git ls-files '**.py*') --py36-plus
 
 Write-Host "`nRunning Pyright..."

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -15,17 +15,21 @@ flake8-bugbear
 flake8-class-attributes-order
 flake8-comprehensions>=3.8  # flake8 5 support
 flake8-datetimez
+flake8-isort>=4.2,<=5.0  # flake8 5 support ; Breaking issue (https://github.com/gforcada/flake8-isort/issues/128)
 flake8-pyi>=22.10.0  # Fixes for negative numbers
 flake8-quotes
 flake8-simplify
 isort
 pep8-naming
 pylint>=2.14,<3.0.0  # New checks  # 3.0 still in pre-release
-pyright>=1.1.276  # Typeshed update
 unify
 #
 # Run `./scripts/designer.ps1` to quickly open the bundled PyQt Designer.
 # Can also be downloaded externally as a non-python package
 qt6-applications
 # Types
+types-d3dshot
+types-keyboard
+types-pyinstaller
+types-pywin32
 typing-extensions

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -6,8 +6,7 @@
 # Dependencies
 -r requirements.txt
 #
-# Linters and formatters
-add-trailing-comma>=2.3.0  # Added support for with statement
+# Linters
 bandit
 flake8>=5  # flake8-pyi deprecation warnings
 flake8-builtins
@@ -19,9 +18,12 @@ flake8-isort>=4.2,<=5.0  # flake8 5 support ; Breaking issue (https://github.com
 flake8-pyi>=22.10.0  # Fixes for negative numbers
 flake8-quotes
 flake8-simplify
-isort
 pep8-naming
 pylint>=2.14,<3.0.0  # New checks  # 3.0 still in pre-release
+# Formatters
+add-trailing-comma>=2.3.0  # Added support for with statement
+autopep8>=2.0.0 # New checks
+isort
 unify
 #
 # Run `./scripts/designer.ps1` to quickly open the bundled PyQt Designer.

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -7,7 +7,7 @@
 -r requirements.txt
 #
 # Linters and formatters
-add-trailing-comma
+add-trailing-comma>=2.3.0  # Added support for with statement
 bandit
 flake8>=5  # flake8-pyi deprecation warnings
 flake8-builtins
@@ -15,10 +15,10 @@ flake8-bugbear
 flake8-class-attributes-order
 flake8-comprehensions>=3.8  # flake8 5 support
 flake8-datetimez
-flake8-isort>=4.2  # flake8 5 support
 flake8-pyi>=22.10.0  # Fixes for negative numbers
 flake8-quotes
 flake8-simplify
+isort
 pep8-naming
 pylint>=2.14,<3.0.0  # New checks  # 3.0 still in pre-release
 pyright>=1.1.276  # Typeshed update

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -12,23 +12,26 @@
 # Dependencies:
 certifi
 ImageHash>=4.3.1  # Contains type information + setup as package not module
-keyboard
+git+https://github.com/Avasam/keyboard.git@fix-563#egg=keyboard  # Fix install on linux-ci https://github.com/boppreh/keyboard/pull/568
 numpy>=1.23  # Updated types
 opencv-python-headless>=4.6  # Breaking changes importing cv2.cv2
 packaging
-Pillow>=7.2.0  # https://github.com/SerpentAI/D3DShot/issues/44
+Pillow>=9.2 # gnome-screeshot checks
 psutil
 PyAutoGUI
-git+https://github.com/andreaschiavinato/python_grabber.git#egg=pygrabber  # Completed types
 PyQt6>=6.2.1  # Python 3.10 support
 requests
 toml
-# Windows-only
-git+https://github.com/ranchen421/D3DShot.git#egg=D3DShot  # D3DShot from PyPI with Pillow>=7.2.0 will install 0.1.3 instead of 0.1.5
-pywin32>=301
-winsdk>=v1.0.0b4
 #
 # Build and compile resources
 PyInstaller>=5.2  # opencv-python 4.6 support
 pyinstaller-hooks-contrib>=2022.9  # opencv-python 4.6 support. Changes for pywintypes and comtypes
-PySide6
+PySide6>=6.2.2  # Apple silicon support
+#
+# https://peps.python.org/pep-0508/#environment-markers
+#
+# Windows-only dependencies:
+git+https://github.com/andreaschiavinato/python_grabber.git#egg=pygrabber ; sys_platform == 'win32'  # Completed types
+pywin32>=301 ; sys_platform == 'win32'
+winsdk>=v1.0.0b4 ; sys_platform == 'win32'
+git+https://github.com/ranchen421/D3DShot.git#egg=D3DShot ; sys_platform == 'win32'  # D3DShot from PyPI with Pillow>=7.2.0 will install 0.1.3 instead of 0.1.5

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -19,7 +19,7 @@ packaging
 Pillow>=7.2.0  # https://github.com/SerpentAI/D3DShot/issues/44
 psutil
 PyAutoGUI
-git+https://github.com/Avasam/python_grabber.git@complete-types#egg=pygrabber  # https://github.com/andreaschiavinato/python_grabber/pull/18
+git+https://github.com/andreaschiavinato/python_grabber.git#egg=pygrabber  # Completed types
 PyQt6>=6.2.1  # Python 3.10 support
 requests
 toml

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -582,15 +582,22 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
                 if split_delay > 0 and not self.waiting_for_split_delay:
                     split_time = round(time() + split_delay * 1000)
                     self.waiting_for_split_delay = True
-                    self.next_image_button.setEnabled(False)
-                    self.previous_image_button.setEnabled(False)
-                    self.undo_split_button.setEnabled(False)
-                    self.skip_split_button.setEnabled(False)
+                    buttons_to_disable = [
+                        self.next_image_button,
+                        self.previous_image_button,
+                        self.undo_split_button,
+                        self.skip_split_button,
+                    ]
+                    for button in buttons_to_disable:
+                        button.setEnabled(False)
                     self.current_image_file_label.clear()
 
                     # check for reset while delayed and display a counter of the remaining split delay time
                     if self.__pause_loop(split_delay, "Delayed Split:"):
                         return
+
+                    for button in buttons_to_disable:
+                        button.setEnabled(True)
 
                 self.waiting_for_split_delay = False
 

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -572,6 +572,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
                 if split_delay > 0 and not self.waiting_for_split_delay:
                     split_time = round(time() + split_delay * 1000)
                     self.waiting_for_split_delay = True
+                    self.next_image_button.setEnabled(False)
+                    self.previous_image_button.setEnabled(False)
                     self.undo_split_button.setEnabled(False)
                     self.skip_split_button.setEnabled(False)
                     self.current_image_file_label.clear()
@@ -679,7 +681,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
             return False
         start_time = time()
         # Set a "pause" split image number.
-        # This is done so that it can detect if user hit split/undo split while paused.
+        # This is done so that it can detect if user hit split/undo split while paused/delayed.
         pause_split_image_number = self.split_image_number
         while True:
             # Calculate similarity for reset image

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -257,6 +257,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
         self.timer_start_image.stop()
         self.current_image_file_label.setText("-")
         self.start_image_status_value_label.setText("not found")
+        set_preview_image(self.current_split_image, None, True)
 
         if not (validate_before_parsing(self, started_by_button) and parse_and_validate_images(self)):
             QApplication.processEvents()

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -144,8 +144,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
         # Connecting menu actions
         self.action_view_help.triggered.connect(view_help)
         self.action_about.triggered.connect(lambda: open_about(self))
-        self.action_about_qt.triggered.connect(lambda: about_qt)
-        self.action_about_qt_for_python.triggered.connect(lambda: about_qt_for_python)
+        self.action_about_qt.triggered.connect(about_qt)
+        self.action_about_qt_for_python.triggered.connect(about_qt_for_python)
         self.action_check_for_updates.triggered.connect(lambda: check_for_updates(self))
         self.action_settings.triggered.connect(lambda: open_settings(self))
         self.action_save_profile.triggered.connect(lambda: user_profile.save_settings(self))

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -699,6 +699,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
                 time_delta >= stop_time
                 # Check for skip split / next image:
                 or self.split_image_number > pause_split_image_number
+                # Check for undo split / previous image:
+                or self.split_image_number < pause_split_image_number
             ):
                 break
 
@@ -919,7 +921,7 @@ def seconds_remaining_text(seconds: float):
     return f"{seconds:.1f} second{'' if 0 < seconds <= 1 else 's'} remaining"
 
 
-def is_already_running():
+def is_already_open():
     # When running directly in Python, any AutoSplit process means it's already open
     # When bundled, we must ignore itself and the splash screen
     max_processes = 3 if FROZEN else 1
@@ -938,8 +940,8 @@ def main():
     try:
         app.setWindowIcon(QtGui.QIcon(":/resources/icon.ico"))
 
-        if is_already_running():
-            error_messages.already_running()
+        if is_already_open():
+            error_messages.already_open()
 
         AutoSplit()
 

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -281,8 +281,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
 
         self.split_image_number = 0
 
-        start_pause_time = self.start_image.get_pause_time(self)
-        if not wait_for_delay and start_pause_time > 0:
+        if not wait_for_delay and self.start_image.get_pause_time(self) > 0:
             self.start_image_status_value_label.setText("paused")
             self.table_current_image_highest_label.setText("-")
             self.table_current_image_threshold_label.setText("-")
@@ -542,6 +541,10 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
         self.is_running = True
         self.gui_changes_on_start()
 
+        # Start pause time
+        if self.start_image:
+            self.__pause_loop(self.start_image.get_pause_time(self), "None (Paused).")
+
         # Initialize a few attributes
         self.split_image_number = 0
         self.waiting_for_split_delay = False
@@ -604,8 +607,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
             # If its not the last split image, pause for the amount set by the user
             # A pause loop to check if the user presses skip split, undo split, or reset here.
             # Also updates the current split image text, counting down the time until the next split image
-            pause_time = self.split_image.get_pause_time(self)
-            if self.__pause_loop(pause_time, "None (Paused)."):
+            if self.__pause_loop(self.split_image.get_pause_time(self), "None (Paused)."):
                 return
 
         # loop breaks to here when the last image splits
@@ -794,7 +796,10 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
                 similarity = self.reset_image.compare_with_capture(self, capture)
                 threshold = self.reset_image.get_similarity_threshold(self)
 
-                paused = time() - self.run_start_time <= self.reset_image.get_pause_time(self)
+                pause_times = [self.reset_image.get_pause_time(self)]
+                if self.start_image:
+                    pause_times.append(self.start_image.get_pause_time(self))
+                paused = time() - self.run_start_time <= max(pause_times)
                 if paused:
                     should_reset = False
                     self.table_reset_image_live_label.setText("paused")

--- a/src/AutoSplitImage.py
+++ b/src/AutoSplitImage.py
@@ -6,11 +6,10 @@ from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
-from win32con import MAXBYTE
 
 import error_messages
 from compare import check_if_image_has_transparency, compare_histograms, compare_l2_norm, compare_phash
-from utils import is_valid_image
+from utils import MAXBYTE, is_valid_image
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit

--- a/src/capture_method/BitBltCaptureMethod.py
+++ b/src/capture_method/BitBltCaptureMethod.py
@@ -28,6 +28,7 @@ class BitBltCaptureMethod(CaptureMethodBase):
         selection = autosplit.settings_dict["capture_region"]
         hwnd = autosplit.hwnd
         image: cv2.Mat | None = None
+
         if not self.check_selected_region_exists(autosplit):
             return None, False
 

--- a/src/capture_method/CaptureMethodBase.py
+++ b/src/capture_method/CaptureMethodBase.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 class CaptureMethodBase():
     def __init__(self, autosplit: AutoSplit | None = None):
+        # Some capture methods don't need an initialization process
         pass
 
     def reinitialize(self, autosplit: AutoSplit):
@@ -19,6 +20,7 @@ class CaptureMethodBase():
         self.__init__(autosplit)  # pylint: disable=unnecessary-dunder-call
 
     def close(self, autosplit: AutoSplit):
+        # Some capture methods don't need an initialization process
         pass
 
     def get_frame(self, autosplit: AutoSplit) -> tuple[cv2.Mat | None, bool]:

--- a/src/capture_method/DesktopDuplicationCaptureMethod.py
+++ b/src/capture_method/DesktopDuplicationCaptureMethod.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ctypes
-import ctypes.wintypes
 from typing import TYPE_CHECKING, cast
 
 import cv2

--- a/src/capture_method/VideoCaptureDeviceCaptureMethod.py
+++ b/src/capture_method/VideoCaptureDeviceCaptureMethod.py
@@ -63,10 +63,10 @@ class VideoCaptureDeviceCaptureMethod(CaptureMethodBase):
             self.capture_device.release()
             autosplit.show_error_signal.emit(
                 lambda: exception_traceback(
+                    error,
                     "AutoSplit encountered an unhandled exception while "
                     + "trying to grab a frame and has stopped capture. "
                     + CREATE_NEW_ISSUE_MESSAGE,
-                    error,
                 ),
             )
 
@@ -98,7 +98,6 @@ class VideoCaptureDeviceCaptureMethod(CaptureMethodBase):
         self.capture_device.release()
 
     def get_frame(self, autosplit: AutoSplit):
-        selection = autosplit.settings_dict["capture_region"]
         if not self.check_selected_region_exists(autosplit):
             return None, False
 
@@ -108,6 +107,7 @@ class VideoCaptureDeviceCaptureMethod(CaptureMethodBase):
         if not is_valid_image(image):
             return None, is_old_image
 
+        selection = autosplit.settings_dict["capture_region"]
         # Ensure we can't go OOB of the image
         y = min(selection["y"], image.shape[0] - 1)
         x = min(selection["x"], image.shape[1] - 1)

--- a/src/capture_method/__init__.py
+++ b/src/capture_method/__init__.py
@@ -95,6 +95,7 @@ class CaptureMethodDict(OrderedDict[CaptureMethodEnum, CaptureMethodInfo]):
         if index <= 0:
             return first(self)
         return list(self.keys())[index]
+
     if TYPE_CHECKING:  # noqa: CCE002
         __getitem__ = None  # pyright: ignore[reportGeneralTypeIssues]  # Disallow unsafe get
 

--- a/src/capture_method/__init__.py
+++ b/src/capture_method/__init__.py
@@ -4,9 +4,9 @@ import asyncio
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum, EnumMeta, unique
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, cast
 
-from pygrabber import dshow_graph
+from pygrabber.dshow_graph import FilterGraph
 
 from capture_method.BitBltCaptureMethod import BitBltCaptureMethod
 from capture_method.CaptureMethodBase import CaptureMethodBase
@@ -14,7 +14,7 @@ from capture_method.DesktopDuplicationCaptureMethod import DesktopDuplicationCap
 from capture_method.ForceFullContentRenderingCaptureMethod import ForceFullContentRenderingCaptureMethod
 from capture_method.VideoCaptureDeviceCaptureMethod import VideoCaptureDeviceCaptureMethod
 from capture_method.WindowsGraphicsCaptureMethod import WindowsGraphicsCaptureMethod
-from utils import WINDOWS_BUILD_NUMBER, get_direct3d_device
+from utils import WINDOWS_BUILD_NUMBER, first, try_get_direct3d_device
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
@@ -75,27 +75,38 @@ class CaptureMethodEnum(Enum, metaclass=CaptureMethodMeta):
 
 
 class CaptureMethodDict(OrderedDict[CaptureMethodEnum, CaptureMethodInfo]):
+    def get_index(self, capture_method: str | CaptureMethodEnum):
+        """
+        Returns 0 if the capture_method is invalid or unsupported
+        """
+        try:
+            return list(self.keys()).index(cast(CaptureMethodEnum, capture_method))
+        except ValueError:
+            return 0
 
     def get_method_by_index(self, index: int):
+        """
+        Returns the `CaptureMethodEnum` at index.
+        If index is invalid, returns the first (default) `CaptureMethodEnum`.
+        Returns `CaptureMethodEnum.NONE` if there are no capture methods available.
+        """
         if len(self) <= 0:
             return CaptureMethodEnum.NONE
-        if index < 0:
-            return next(iter(self))
+        if index <= 0:
+            return first(self)
         return list(self.keys())[index]
+    if TYPE_CHECKING:  # noqa: CCE002
+        __getitem__ = None  # pyright: ignore[reportGeneralTypeIssues]  # Disallow unsafe get
 
-    def __getitem__(self, key: CaptureMethodEnum):
-        if key == CaptureMethodEnum.NONE:
+    def get(self, __key: CaptureMethodEnum):
+        """
+        Returns the `CaptureMethodInfo` for `CaptureMethodEnum` if `CaptureMethodEnum` is available,
+        else defaults to the first available `CaptureMethodEnum`.
+        Returns the `CaptureMethodBase` (default) implementation if there's no capture methods.
+        """
+        if __key == CaptureMethodEnum.NONE or len(self) <= 0:
             return NONE_CAPTURE_METHOD
-        try:
-            return super().__getitem__(key)
-        # If requested method does not exists...
-        except KeyError:
-            try:
-                # ...fallback to the first one
-                return super().__getitem__(self.get_method_by_index(0))
-            except KeyError:
-                # ...fallback to an empty capture method to avoid crashes
-                return NONE_CAPTURE_METHOD
+        return super().get(__key, first(self.values()))
 
 
 NONE_CAPTURE_METHOD = CaptureMethodInfo(
@@ -105,19 +116,24 @@ NONE_CAPTURE_METHOD = CaptureMethodInfo(
     implementation=CaptureMethodBase,
 )
 
-CAPTURE_METHODS = CaptureMethodDict({
-    CaptureMethodEnum.BITBLT: CaptureMethodInfo(
-        name="BitBlt",
-        short_description="fastest, least compatible",
-        description=(
-            "\nA good default fast option. But it cannot properly record "
-            "\nOpenGL, Hardware Accelerated or Exclusive Fullscreen windows. "
-            "\nThe smaller the selected region, the more efficient it is. "
-        ),
-
-        implementation=BitBltCaptureMethod,
+CAPTURE_METHODS = CaptureMethodDict()
+CAPTURE_METHODS[CaptureMethodEnum.BITBLT] = CaptureMethodInfo(
+    name="BitBlt",
+    short_description="fastest, least compatible",
+    description=(
+        "\nA good default fast option. But it cannot properly record "
+        "\nOpenGL, Hardware Accelerated or Exclusive Fullscreen windows. "
+        "\nThe smaller the selected region, the more efficient it is. "
     ),
-    CaptureMethodEnum.WINDOWS_GRAPHICS_CAPTURE: CaptureMethodInfo(
+
+    implementation=BitBltCaptureMethod,
+)
+if (  # Windows Graphics Capture requires a minimum Windows Build
+    WINDOWS_BUILD_NUMBER >= WGC_MIN_BUILD
+    # Our current implementation of Windows Graphics Capture does not ensure we can get an ID3DDevice
+    and try_get_direct3d_device()
+):
+    CAPTURE_METHODS[CaptureMethodEnum.WINDOWS_GRAPHICS_CAPTURE] = CaptureMethodInfo(
         name="Windows Graphics Capture",
         short_description="fast, most compatible, capped at 60fps",
         description=(
@@ -129,63 +145,46 @@ CAPTURE_METHODS = CaptureMethodDict({
             "\nCaps at around 60 FPS. "
         ),
         implementation=WindowsGraphicsCaptureMethod,
+    )
+CAPTURE_METHODS[CaptureMethodEnum.DESKTOP_DUPLICATION] = CaptureMethodInfo(
+    name="Direct3D Desktop Duplication",
+    short_description="slower, bound to display",
+    description=(
+        "\nDuplicates the desktop using Direct3D. "
+        "\nIt can record OpenGL and Hardware Accelerated windows. "
+        "\nAbout 10-15x slower than BitBlt. Not affected by window size. "
+        "\nOverlapping windows will show up and can't record across displays. "
     ),
-    CaptureMethodEnum.DESKTOP_DUPLICATION: CaptureMethodInfo(
-        name="Direct3D Desktop Duplication",
-        short_description="slower, bound to display",
-        description=(
-            "\nDuplicates the desktop using Direct3D. "
-            "\nIt can record OpenGL and Hardware Accelerated windows. "
-            "\nAbout 10-15x slower than BitBlt. Not affected by window size. "
-            "\nOverlapping windows will show up and can't record across displays. "
-        ),
-        implementation=DesktopDuplicationCaptureMethod,
+    implementation=DesktopDuplicationCaptureMethod,
+)
+CAPTURE_METHODS[CaptureMethodEnum.PRINTWINDOW_RENDERFULLCONTENT] = CaptureMethodInfo(
+    name="Force Full Content Rendering",
+    short_description="very slow, can affect rendering pipeline",
+    description=(
+        "\nUses BitBlt behind the scene, but passes a special flag "
+        "\nto PrintWindow to force rendering the entire desktop. "
+        "\nAbout 10-15x slower than BitBlt based on original window size "
+        "\nand can mess up some applications' rendering pipelines. "
     ),
-    CaptureMethodEnum.PRINTWINDOW_RENDERFULLCONTENT: CaptureMethodInfo(
-        name="Force Full Content Rendering",
-        short_description="very slow, can affect rendering pipeline",
-        description=(
-            "\nUses BitBlt behind the scene, but passes a special flag "
-            "\nto PrintWindow to force rendering the entire desktop. "
-            "\nAbout 10-15x slower than BitBlt based on original window size "
-            "\nand can mess up some applications' rendering pipelines. "
-        ),
-        implementation=ForceFullContentRenderingCaptureMethod,
+    implementation=ForceFullContentRenderingCaptureMethod,
+)
+CAPTURE_METHODS[CaptureMethodEnum.VIDEO_CAPTURE_DEVICE] = CaptureMethodInfo(
+    name="Video Capture Device",
+    short_description="see below",
+    description=(
+        "\nUses a Video Capture Device, like a webcam, virtual cam, or capture card. "
+        "\nYou can select one below. "
+        "\nThere are currently performance issues, but it might be more convenient. "
+        "\nIf you want to use this with OBS' Virtual Camera, use the Virtualcam plugin instead "
+        "\nhttps://github.com/Avasam/obs-virtual-cam/releases"
     ),
-    CaptureMethodEnum.VIDEO_CAPTURE_DEVICE: CaptureMethodInfo(
-        name="Video Capture Device",
-        short_description="see below",
-        description=(
-            "\nUses a Video Capture Device, like a webcam, virtual cam, or capture card. "
-            "\nYou can select one below. "
-            "\nThere are currently performance issues, but it might be more convenient. "
-            "\nIf you want to use this with OBS' Virtual Camera, use the Virtualcam plugin instead "
-            "\nhttps://github.com/Avasam/obs-virtual-cam/releases"
-        ),
-        implementation=VideoCaptureDeviceCaptureMethod,
-    ),
-})
-
-
-def try_get_direct3d_device():
-    try:
-        return get_direct3d_device()
-    except OSError:
-        return None
-
-
-# Detect and remove unsupported capture methods
-if (  # Windows Graphics Capture requires a minimum Windows Build
-    WINDOWS_BUILD_NUMBER < WGC_MIN_BUILD
-    # Our current implementation of Windows Graphics Capture does not ensure we can get an ID3DDevice
-    or not try_get_direct3d_device()
-):
-    CAPTURE_METHODS.pop(CaptureMethodEnum.WINDOWS_GRAPHICS_CAPTURE)
+    implementation=VideoCaptureDeviceCaptureMethod,
+)
 
 
 def change_capture_method(selected_capture_method: CaptureMethodEnum, autosplit: AutoSplit):
     autosplit.capture_method.close(autosplit)
-    autosplit.capture_method = CAPTURE_METHODS[selected_capture_method].implementation(autosplit)
+    autosplit.capture_method = CAPTURE_METHODS.get(selected_capture_method).implementation(autosplit)
     if selected_capture_method == CaptureMethodEnum.VIDEO_CAPTURE_DEVICE:
         autosplit.select_region_button.setDisabled(True)
         autosplit.select_window_button.setDisabled(True)
@@ -200,12 +199,19 @@ class CameraInfo():
     name: str
     occupied: bool
     backend: str
-    size: tuple[int, int]
+    resolution: tuple[int, int] | None
+
+
+def get_input_device_resolution(index: int):
+    filter_graph = FilterGraph()
+    filter_graph.add_video_input_device(index)
+    resolution = filter_graph.get_input_device().get_current_format()
+    filter_graph.remove_filters()
+    return resolution
 
 
 async def get_all_video_capture_devices() -> list[CameraInfo]:
-    filter_graph = dshow_graph.FilterGraph()
-    named_video_inputs = filter_graph.get_input_devices()
+    named_video_inputs = FilterGraph().get_input_devices()
 
     async def get_camera_info(index: int, device_name: str):
         backend = ""
@@ -225,10 +231,8 @@ async def get_all_video_capture_devices() -> list[CameraInfo]:
         #         else None
         # finally:
         #     video_capture.release()
-        filter_graph.add_video_input_device(index)
-        size = filter_graph.get_input_device().get_current_format()
-        filter_graph.remove_filters()
-        return CameraInfo(index, device_name, False, backend, size)
+
+        return CameraInfo(index, device_name, False, backend, get_input_device_resolution(index))
 
     future = asyncio.gather(
         *[

--- a/src/compare.py
+++ b/src/compare.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from math import sqrt
+
 import cv2
 import imagehash
 from PIL import Image
-from win32con import MAXBYTE
 
-from utils import is_valid_image
+from utils import MAXBYTE, is_valid_image
 
 MAXRANGE = MAXBYTE + 1
 CHANNELS = [0, 1, 2]
@@ -46,9 +47,9 @@ def compare_l2_norm(source: cv2.Mat, capture: cv2.Mat, mask: cv2.Mat | None = No
     error = cv2.norm(source, capture, cv2.NORM_L2, mask)
 
     # The L2 Error is summed across all pixels, so this normalizes
-    max_error: float = (source.size ** 0.5) * MAXBYTE \
+    max_error = sqrt(source.size) * MAXBYTE \
         if not is_valid_image(mask)\
-        else (3 * cv2.countNonZero(mask) * MAXBYTE * MAXBYTE) ** 0.5
+        else sqrt(cv2.countNonZero(mask) * MASK_SIZE_MULTIPLIER)
 
     if not max_error:
         return 0.0

--- a/src/error_messages.py
+++ b/src/error_messages.py
@@ -115,13 +115,15 @@ def invalid_hotkey(hotkey_name: str):
 
 
 def no_settings_file_on_open():
-    set_text_message("No settings file found. One can be loaded on open if placed in the same folder as AutoSplit.exe")
+    set_text_message(
+        "No settings file found. One can be loaded on open if placed in the same folder as the AutoSplit executable.",
+    )
 
 
 def too_many_settings_files_on_open():
     set_text_message(
         "Too many settings files found. "
-        + "Only one can be loaded on open if placed in the same folder as AutoSplit.exe",
+        + "Only one can be loaded on open if placed in the same folder as the AutoSplit executable.",
     )
 
 
@@ -149,7 +151,10 @@ def already_running():
     )
 
 
-def exception_traceback(message: str, exception: BaseException):
+def exception_traceback(exception: BaseException, message: str = ""):
+    if not message:
+        message = "AutoSplit encountered an unhandled exception and will try to recover, " + \
+            f"however, there is no guarantee it will keep working properly. {CREATE_NEW_ISSUE_MESSAGE}"
     set_text_message(
         message,
         "\n".join(traceback.format_exception(None, exception, exception.__traceback__)),
@@ -176,21 +181,15 @@ def make_excepthook(autosplit: AutoSplit):
         ):
             return
         # Whithin LiveSplit excepthook needs to use MainWindow's signals to show errors
-        autosplit.show_error_signal.emit(
-            lambda: exception_traceback(
-                "AutoSplit encountered an unhandled exception and will try to recover, "
-                + f"however, there is no guarantee it will keep working properly. {CREATE_NEW_ISSUE_MESSAGE}",
-                exception,
-            ),
-        )
+        autosplit.show_error_signal.emit(lambda: exception_traceback(exception))
     return excepthook
 
 
 def handle_top_level_exceptions(exception: Exception):
-    message = f"AutoSplit encountered an unrecoverable exception and will now close. {CREATE_NEW_ISSUE_MESSAGE}"
+    message = f"AutoSplit encountered an unrecoverable exception and will likely now close. {CREATE_NEW_ISSUE_MESSAGE}"
     # Print error to console if not running in executable
     if FROZEN:
-        exception_traceback(message, exception)
+        exception_traceback(exception, message)
     else:
         traceback.print_exception(type(exception), exception, exception.__traceback__)
     sys.exit(1)

--- a/src/error_messages.py
+++ b/src/error_messages.py
@@ -142,7 +142,7 @@ def stdin_lost():
     set_text_message("stdin not supported or lost, external control like LiveSplit integration will not work.")
 
 
-def already_running():
+def already_open():
     set_text_message(
         "An instance of AutoSplit is already running.<br/>Are you sure you want to open a another one?",
         "",

--- a/src/hotkeys.py
+++ b/src/hotkeys.py
@@ -197,9 +197,9 @@ def __read_hotkey():
 def __remove_key_already_set(autosplit: AutoSplit, key_name: str):
     for hotkey in HOTKEYS:
         settings_key = f"{hotkey}_hotkey"
-        if autosplit.settings_dict[settings_key] == key_name:
+        if autosplit.settings_dict[settings_key] == key_name:  # pyright: ignore[reportGeneralTypeIssues]
             _unhook(getattr(autosplit, f"{hotkey}_hotkey"))
-            autosplit.settings_dict[settings_key] = ""
+            autosplit.settings_dict[settings_key] = ""  # pyright: ignore[reportGeneralTypeIssues]
             if autosplit.SettingsWidget:
                 getattr(autosplit.SettingsWidget, f"{hotkey}_input").setText("")
 
@@ -280,8 +280,7 @@ def set_hotkey(autosplit: AutoSplit, hotkey: Hotkey, preselected_hotkey_name: st
 
             if autosplit.SettingsWidget:
                 getattr(autosplit.SettingsWidget, f"{hotkey}_input").setText(hotkey_name)
-            autosplit.settings_dict[f"{hotkey}_hotkey"] = hotkey_name
-            autosplit.after_setting_hotkey_signal.emit()
+            autosplit.settings_dict[f"{hotkey}_hotkey"] = hotkey_name  # pyright: ignore[reportGeneralTypeIssues]
         except Exception as exception:   # pylint: disable=broad-except # We really want to catch everything here
             error = exception
             autosplit.show_error_signal.emit(lambda: error_messages.exception_traceback(error))

--- a/src/hotkeys.py
+++ b/src/hotkeys.py
@@ -8,7 +8,7 @@ import pyautogui
 from PyQt6 import QtWidgets
 
 import error_messages
-from utils import START_AUTO_SPLITTER_TEXT, fire_and_forget, is_digit
+from utils import fire_and_forget, is_digit
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
@@ -43,7 +43,7 @@ def after_setting_hotkey(autosplit: AutoSplit):
     Do all of these things after you set a hotkey.
     A signal connects to this because changing GUI stuff is only possible in the main thread
     """
-    if autosplit.start_auto_splitter_button.text() == START_AUTO_SPLITTER_TEXT:
+    if not autosplit.is_running:
         autosplit.start_auto_splitter_button.setEnabled(True)
     if autosplit.SettingsWidget:
         for hotkey in HOTKEYS:

--- a/src/menu_bar.py
+++ b/src/menu_bar.py
@@ -112,16 +112,6 @@ def check_for_updates(autosplit: AutoSplit, check_on_open: bool = False):
     autosplit.CheckForUpdatesThread.start()
 
 
-def get_capture_method_index(capture_method: str | CaptureMethodEnum):
-    """
-    Returns 0 if the capture_method is invalid or unsupported
-    """
-    try:
-        return list(CAPTURE_METHODS.keys()).index(cast(CaptureMethodEnum, capture_method))
-    except ValueError:
-        return 0
-
-
 class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):
     __video_capture_devices: list[CameraInfo] = []
     """
@@ -257,7 +247,7 @@ class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):
 
             set_hotkey_hotkey_button.clicked.connect(hotkey_connect(hotkey))
             # Make it very clear that hotkeys are not used when auto-controlled
-            if autosplit.is_auto_controlled:
+            if autosplit.is_auto_controlled and hotkey != "toggle_auto_reset_image":
                 set_hotkey_hotkey_button.setEnabled(False)
                 hotkey_input.setEnabled(False)
 
@@ -266,7 +256,7 @@ class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):
         self.fps_limit_spinbox.setValue(autosplit.settings_dict["fps_limit"])
         self.live_capture_region_checkbox.setChecked(autosplit.settings_dict["live_capture_region"])
         self.capture_method_combobox.setCurrentIndex(
-            get_capture_method_index(autosplit.settings_dict["capture_method"]),
+            CAPTURE_METHODS.get_index(autosplit.settings_dict["capture_method"]),
         )
         self.capture_device_combobox.currentIndexChanged.connect(
             lambda: self.__set_value("capture_device_id", self.__capture_device_changed()),

--- a/src/menu_bar.py
+++ b/src/menu_bar.py
@@ -243,7 +243,12 @@ class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):
         for hotkey in HOTKEYS:
             hotkey_input: QtWidgets.QLineEdit = getattr(self, f"{hotkey}_input")
             set_hotkey_hotkey_button: QtWidgets.QPushButton = getattr(self, f"set_{hotkey}_hotkey_button")
-            hotkey_input.setText(cast(str, autosplit.settings_dict[f"{hotkey}_hotkey"]))
+            hotkey_input.setText(
+                cast(
+                    str,
+                    autosplit.settings_dict[f"{hotkey}_hotkey"],  # pyright: ignore[reportGeneralTypeIssues]
+                ),
+            )
 
             set_hotkey_hotkey_button.clicked.connect(hotkey_connect(hotkey))
             # Make it very clear that hotkeys are not used when auto-controlled

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -105,8 +105,8 @@ def select_region(autosplit: AutoSplit):
 
     left_bounds, top_bounds, *_ = get_window_bounds(hwnd)
     window_x, window_y, *_ = win32gui.GetWindowRect(hwnd)
-    offset_x = window_x - left_bounds
-    offset_y = window_y - top_bounds
+    offset_x = window_x + left_bounds
+    offset_y = window_y + top_bounds
     __set_region_values(
         autosplit,
         left=x - offset_x,

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -166,7 +166,9 @@ def load_settings(autosplit: AutoSplit, from_path: str = ""):
         return
 
     autosplit.last_successfully_loaded_settings_file_path = load_settings_file_path
-    autosplit.load_start_image_signal.emit()
+    # TODO: Should this check be in `__load_start_image` ?
+    if not autosplit.is_running:
+        autosplit.load_start_image_signal.emit()
 
 
 def load_settings_on_open(autosplit: AutoSplit):

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, TypedDict, cast
 
-import keyboard
 import toml
 from PyQt6 import QtCore, QtWidgets
 
 import error_messages
 from capture_method import CAPTURE_METHODS, CaptureMethodEnum, Region, change_capture_method
 from gen import design
-from hotkeys import HOTKEYS, set_hotkey
+from hotkeys import HOTKEYS, remove_all_hotkeys, set_hotkey
 from utils import auto_split_directory
 
 if TYPE_CHECKING:
@@ -133,7 +132,7 @@ def __load_settings_from_file(autosplit: AutoSplit, load_settings_file_path: str
         autosplit.show_error_signal.emit(error_messages.invalid_settings)
         return False
 
-    keyboard.unhook_all()
+    remove_all_hotkeys()
     if not autosplit.is_auto_controlled:
         for hotkey, hotkey_name in [(hotkey, f"{hotkey}_hotkey") for hotkey in HOTKEYS]:
             if autosplit.settings_dict[hotkey_name]:

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -135,8 +135,12 @@ def __load_settings_from_file(autosplit: AutoSplit, load_settings_file_path: str
     remove_all_hotkeys()
     if not autosplit.is_auto_controlled:
         for hotkey, hotkey_name in [(hotkey, f"{hotkey}_hotkey") for hotkey in HOTKEYS]:
-            if autosplit.settings_dict[hotkey_name]:
-                set_hotkey(autosplit, hotkey, cast(str, autosplit.settings_dict[hotkey_name]))
+            if autosplit.settings_dict[hotkey_name]:  # pyright: ignore[reportGeneralTypeIssues]
+                set_hotkey(
+                    autosplit,
+                    hotkey,
+                    cast(str, autosplit.settings_dict[hotkey_name]),  # pyright: ignore[reportGeneralTypeIssues]
+                )
 
     change_capture_method(cast(CaptureMethodEnum, autosplit.settings_dict["capture_method"]), autosplit)
     if autosplit.settings_dict["capture_method"] != CaptureMethodEnum.VIDEO_CAPTURE_DEVICE:

--- a/src/utils.py
+++ b/src/utils.py
@@ -18,7 +18,8 @@ from winsdk.windows.media.capture import MediaCapture
 from gen.build_vars import AUTOSPLIT_BUILD_NUMBER, AUTOSPLIT_GITHUB_REPOSITORY
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeGuard
+    from typing_extensions import ParamSpec, TypeGuard
+    P = ParamSpec("P")
 
 DWMWA_EXTENDED_FRAME_BOUNDS = 9
 
@@ -80,6 +81,19 @@ def get_window_bounds(hwnd: int) -> tuple[int, int, int, int]:
     return window_left_bounds, window_top_bounds, window_width, window_height
 
 
+def open_file(file_path: str):
+    os.startfile(file_path)  # nosec B606
+
+
+def get_or_create_eventloop():
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return asyncio.get_event_loop()
+
+
 def get_direct3d_device():
     direct_3d_device = LearningModelDevice(LearningModelDeviceKind.DIRECT_X_HIGH_PERFORMANCE).direct3_d11_device
     if not direct_3d_device:
@@ -97,6 +111,13 @@ def get_direct3d_device():
     return direct_3d_device
 
 
+def try_get_direct3d_device():
+    try:
+        return get_direct3d_device()
+    except OSError:
+        return None
+
+
 def fire_and_forget(func: Callable[..., Any]):
     """
     Runs synchronous function asynchronously without waiting for a response
@@ -110,19 +131,41 @@ def fire_and_forget(func: Callable[..., Any]):
             thread = Thread(target=func, args=args, kwargs=kwargs)
             thread.start()
             return thread
-        return asyncio.get_event_loop().run_in_executor(None, func, *args, *kwargs)
+        return get_or_create_eventloop().run_in_executor(None, func, *args, *kwargs)
 
     return wrapped
 
 
+def getTopWindowAt(x: int, y: int):  # noqa: N802
+    # Immitating PyWinCTL's function
+    class Win32Window():
+        def __init__(self, hwnd: int) -> None:
+            self._hWnd = hwnd
+
+        def getHandle(self):  # noqa: N802
+            return self._hWnd
+
+        @property
+        def title(self):
+            return win32gui.GetWindowText(self._hWnd)
+    hwnd = win32gui.WindowFromPoint((x, y))
+
+    # Want to pull the parent window from the window handle
+    # By using GetAncestor we are able to get the parent window instead of the owner window.
+    while win32gui.IsChild(win32gui.GetParent(hwnd), hwnd):
+        hwnd = ctypes.windll.user32.GetAncestor(hwnd, 2)
+    return Win32Window(hwnd) if hwnd else None
+
+
 # Environment specifics
-WINDOWS_BUILD_NUMBER = int(version().split(".")[2])
+WINDOWS_BUILD_NUMBER = int(version().split(".")[2]) if sys.platform == "win32" else -1
 FIRST_WIN_11_BUILD = 22000
 """AutoSplit Version number"""
 FROZEN = hasattr(sys, "frozen")
 """Running from build made by PyInstaller"""
 auto_split_directory = os.path.dirname(sys.executable if FROZEN else os.path.abspath(__file__))
-"""The directory of either AutoSplit.exe or AutoSplit.py"""
+"""The directory of either the AutoSplit executable or AutoSplit.py"""
+MAXBYTE = 255
 
 # Shared strings
 # Set AUTOSPLIT_BUILD_NUMBER to an empty string to generate a clean version number

--- a/src/utils.py
+++ b/src/utils.py
@@ -171,5 +171,4 @@ MAXBYTE = 255
 # Set AUTOSPLIT_BUILD_NUMBER to an empty string to generate a clean version number
 # AUTOSPLIT_BUILD_NUMBER = ""  # pyright: ignore[reportConstantRedefinition]  # noqa: F811
 AUTOSPLIT_VERSION = "2.0.0-alpha.6" + (f"-{AUTOSPLIT_BUILD_NUMBER}" if AUTOSPLIT_BUILD_NUMBER else "")
-START_AUTO_SPLITTER_TEXT = "Start Auto Splitter"
 GITHUB_REPOSITORY = AUTOSPLIT_GITHUB_REPOSITORY

--- a/src/utils.py
+++ b/src/utils.py
@@ -175,5 +175,5 @@ MAXBYTE = 255
 # Shared strings
 # Set AUTOSPLIT_BUILD_NUMBER to an empty string to generate a clean version number
 # AUTOSPLIT_BUILD_NUMBER = ""  # pyright: ignore[reportConstantRedefinition]  # noqa: F811
-AUTOSPLIT_VERSION = "2.0.0-alpha.6" + (f"-{AUTOSPLIT_BUILD_NUMBER}" if AUTOSPLIT_BUILD_NUMBER else "")
+AUTOSPLIT_VERSION = "2.0.0-beta.1" + (f"-{AUTOSPLIT_BUILD_NUMBER}" if AUTOSPLIT_BUILD_NUMBER else "")
 GITHUB_REPOSITORY = AUTOSPLIT_GITHUB_REPOSITORY


### PR DESCRIPTION
- Added summary of histogram in readme
- Move build instructions to a different file
- Backported changes from linux branch #153.
  - Mostly wording and setup changes to reduce eventual merge conflicts.
  - Use PyWinCTL-like code for regions
  - Abstracted `os.startfile`
- Improved usage of pyright and formatters
- Created a proper `is_running` variable rather than loosely comparing against UI text
- Fix #185 (broken links)
- Completed #183 (disabling next/previous images when delaying)
- Fixed loading and clearing of start image from loading profile
- Fix intervals between comparisons (it was always a fraction, rounded down to 0)
- Completed #182 (Add support for pause time after start image)
- Get the Direct3D device from `MediaCapture`. `LearningModelDevice` is now the fallback
- Fix #184 (Re-enable buttons after delay time has passed)
- Centered region labels
- Use default values for error messages method
- Make `CaptureMethodDict` accesses safer
- Use `sqrt` over  `**` (performance is between equal to negligibly better. More importantly it's type-safe)
- Keep all `keyboard`-related code in `hotkeys.py`. Don't leak implementation! (`keyboard` has issues and we might want to move away from it some day)
- Wrap `read_and_set_hotkey` with a try-catch. Exceptions from code run asynchronously are not automatically caught!
