### PR TITLE
Fixed region selection on Linux

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -153,10 +153,10 @@ jobs:
         run: |
           $version = "v${{ needs.Build.outputs.AUTOSPLIT_VERSION }}"
           $body = [uri]::EscapeDataString(((@'
-          # Which Asset should I use?
+          # Which Asset should I download?
 
           - Python: This is the Python version bundled with AutoSplit. Try the newer version, it should be functionally identical, with a marginal performance boost. If you have any issue with it, please [report it here](https://github.com/Toufool/AutoSplit/issues) or on the Discord server and use an older Python version in the mean time.
-          - `Arm64` vs `x64`: [Check your Platform Architecture](https://www.checkadevice.com/tests/system/) (note that `x86_x64` and `x64` is the same). If you're still unsure, `x64` will work either way. `Arm64` should be more efficient.
+          - `arm64` vs `x64`: [Check your Processor Platform Architecture](https://www.checkadevice.com/tests/system/) (note that `x86_64` and `x64` means the same). If you're still unsure, `x64` will work either way. `arm64` should be more efficient.
           - WineCompat: This is for running the Windows executable under Wine on Linux
           '@).Trim() -replace "`n", ''))
           # ^ Removing newline from template because GitHub will actually decode %0A

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -317,6 +317,8 @@ class BaseSelectWidget(QtWidgets.QWidget):
         # Using QApplication to simplify multi-monitor setups, including negative coordinates,
         # in a type-safe, cross-platform manner.
         bounding_rect = QtWidgets.QApplication.primaryScreen().virtualGeometry()
+        self.setGeometry(bounding_rect)
+        self.setFixedSize(bounding_rect.size())  # Prevent move/resizing on Linux
         self.setWindowFlags(
             QtCore.Qt.WindowType.FramelessWindowHint
             | QtCore.Qt.WindowType.WindowStaysOnTopHint
@@ -324,11 +326,9 @@ class BaseSelectWidget(QtWidgets.QWidget):
             # the window position, which is needed for monitors at negative coordinates.
             | QtCore.Qt.WindowType.BypassWindowManagerHint
         )
+        self.show()
         self.setWindowTitle(type(self).__name__)
         self.setWindowOpacity(0.5)
-        self.setGeometry(bounding_rect)
-        self.setFixedSize(bounding_rect.size())  # Prevent move/resizing on Linux
-        self.show()
         self.activateWindow()  # BypassWindowManagerHint skips WM focus; request it explicitly
 
     @override

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -25,17 +25,10 @@ from utils import (
 )
 
 if sys.platform == "win32":
-    import win32api
     import win32gui
-    from win32con import (
-        SM_CXVIRTUALSCREEN,
-        SM_CYVIRTUALSCREEN,
-        SM_XVIRTUALSCREEN,
-        SM_YVIRTUALSCREEN,
-    )
 
 if sys.platform == "linux":
-    from Xlib.display import Display
+    from Xlib.xobject.drawable import Window
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
@@ -144,7 +137,8 @@ def select_region(autosplit: AutoSplit):
         offset_x = window_x + left_bounds
         offset_y = window_y + top_bounds
     else:
-        data = window._xWin.translate_coords(autosplit.hwnd, 0, 0)._data  # pyright:ignore[reportPrivateUsage] # noqa: SLF001
+        root: Window = window._xWin.query_tree().root  # pyright:ignore[reportPrivateUsage] # noqa: SLF001
+        data = root.translate_coords(window._xWin.id, 0, 0)._data  # pyright:ignore[reportPrivateUsage] # noqa: SLF001
         offset_x = data["x"]
         offset_y = data["y"]
 
@@ -319,28 +313,23 @@ class BaseSelectWidget(QtWidgets.QWidget):
 
     def __init__(self):
         super().__init__()
-        # We need to pull the monitor information to correctly draw
-        # the geometry covering all portions of the user's screen.
-        # These parameters create the bounding box with left, top, width, and height
-        if sys.platform == "win32":
-            x = win32api.GetSystemMetrics(SM_XVIRTUALSCREEN)
-            y = win32api.GetSystemMetrics(SM_YVIRTUALSCREEN)
-            width = win32api.GetSystemMetrics(SM_CXVIRTUALSCREEN)
-            height = win32api.GetSystemMetrics(SM_CYVIRTUALSCREEN)
-        else:
-            display = Display()
-            display_geometry = display.screen().root.get_geometry()._data  # noqa: SLF001
-            display.close()
-            x = display_geometry["x"]
-            y = display_geometry["y"]
-            width = display_geometry["width"]
-            height = display_geometry["height"]
-        self.setGeometry(x, y, width, height)
-        self.setFixedSize(width, height)  # Prevent move/resizing on Linux
+        # Pull the full monitors geometry covering all portions of the user's screen.
+        # Using QApplication to simplify multi-monitor setups, including negative coordinates,
+        # in a type-safe, cross-platform manner.
+        bounding_rect = QtWidgets.QApplication.primaryScreen().virtualGeometry()
+        self.setWindowFlags(
+            QtCore.Qt.WindowType.FramelessWindowHint
+            | QtCore.Qt.WindowType.WindowStaysOnTopHint
+            # BypassWindowManagerHint (X11 override-redirect) prevents the WM from clamping
+            # the window position, which is needed for monitors at negative coordinates.
+            | QtCore.Qt.WindowType.BypassWindowManagerHint
+        )
         self.setWindowTitle(type(self).__name__)
         self.setWindowOpacity(0.5)
-        self.setWindowFlags(QtCore.Qt.WindowType.FramelessWindowHint)
+        self.setGeometry(bounding_rect)
+        self.setFixedSize(bounding_rect.size())  # Prevent move/resizing on Linux
         self.show()
+        self.activateWindow()  # BypassWindowManagerHint skips WM focus; request it explicitly
 
     @override
     def keyPressEvent(self, event: QtGui.QKeyEvent):

--- a/src/utils.py
+++ b/src/utils.py
@@ -27,7 +27,7 @@ if sys.platform == "win32":
 
     import win32gui
     import win32ui
-    from pygrabber.dshow_graph import FilterGraph
+    import winerror
 
     type STARTUPINFO = subprocess.STARTUPINFO
 else:
@@ -175,6 +175,13 @@ def get_window_bounds(hwnd: int) -> tuple[int, int, int, int]:
 def get_input_device_resolution(index: int) -> tuple[int, int] | None:
     if sys.platform != "win32":
         return (0, 0)
+    try:
+        from pygrabber.dshow_graph import FilterGraph  # noqa: PLC0415
+    except OSError as exception:
+        # wine can choke on D3D Device Enumeration if missing directshow
+        if exception.winerror != winerror.TYPE_E_CANTLOADLIBRARY:
+            raise
+        return None
     filter_graph = FilterGraph()
     try:
         filter_graph.add_video_input_device(index)


### PR DESCRIPTION
- The selection overlay should be on top in more cases
- The selection overlay should now cover all monitors in multi-monitors setup with negative coordinates
- Region selection works on all monitors (not just the leftmost one)

Fixes #278

I'm slipping in a small unrelated Wine fix since I need to generate builds to test anyway