### PR TITLE
Scripts improvements

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -32,10 +32,6 @@ env:
   GITHUB_EXCLUDE_BUILD_NUMBER: ${{ inputs.excludeBuildNumber }}
   UV_NO_SYNC: true # Avoid accidentally pulling in dependency-groups with uv run
   APPIMAGE_EXTRACT_AND_RUN: true # Avoid needing libfuse2
-  # https://github.com/opencv/opencv-python#source-distributions
-  # Allows building OpenCV on Windows ARM64
-  # https://github.com/opencv/opencv-python/issues/1092#issuecomment-2862538656
-  CMAKE_ARGS: "-DBUILD_opencv_dnn=OFF -DENABLE_NEON=OFF"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -91,10 +87,6 @@ jobs:
             wine-compat: "-WineCompat"
     steps:
       - uses: actions/checkout@v6
-      # https://github.com/astral-sh/uv/issues/12906#issuecomment-3587439179
-      - name: Set UV_PYTHON for ARM runners
-        if: ${{ endsWith(matrix.os, 'arm') }}
-        run: echo "UV_PYTHON=arm64" >> "$GITHUB_ENV"
       # region https://github.com/pyinstaller/pyinstaller/issues/9204
       - name: Set up Python for PyInstaller tk issue on Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -105,7 +97,14 @@ jobs:
       - name: Set up uv for Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ !startsWith(matrix.os, 'ubuntu') && matrix.python-version || null }}
+          # On ARM64, uv defaults to x86_64 Python, force it to aarch64.
+          # https://github.com/astral-sh/uv/issues/12906#issuecomment-3587439179
+          #
+          # On Ubuntu use the global Python install (null) for reason above
+          python-version: >-
+            ${{ (!startsWith(matrix.os, 'ubuntu')
+                && format('{0}-{1}', matrix.python-version, endsWith(matrix.os, 'arm') && 'aarch64' || 'x86_64'))
+              || null }}
       # endregion
       - run: scripts/install.ps1 ${{ matrix.wine-compat }}
         shell: pwsh

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -9,7 +9,7 @@ Push-Location "$PSScriptRoot/.." # Avoid issues with space in path
 try {
   & 'scripts/compile_resources.ps1'
 
-  $SupportsSplashScreen = [System.Convert]::ToBoolean(
+  $SupportsSplashScreen = $Env:GITHUB_JOB -or [System.Convert]::ToBoolean(
     $(uv run --active python -c '
 from PyInstaller.building.splash import Splash
 Splash._check_tcl_tk_compatibility()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -32,15 +32,16 @@ if ($IsLinux) {
 
 if ($IsLinux) {
   if (-not $Env:GITHUB_JOB -or $Env:GITHUB_JOB -eq 'Build') {
-    # System dependencies
-    sudo apt-get update
-    # python3-tk for splash screen
-    # libxcb-cursor-dev for QT_QPA_PLATFORM=xcb
-    # the rest for PySide6
-    sudo apt-get install -y `
-      python3-tk `
-      libxcb-cursor-dev `
-      libegl1 libxkbcommon0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-keysyms1
+    if (Get-Command apt-get -ErrorAction SilentlyContinue) {
+      sudo apt-get update
+      # python3-tk for splash screen
+      # libxcb-cursor-dev for QT_QPA_PLATFORM=xcb
+      # the rest for PySide6
+      sudo apt-get install -y `
+        python3-tk `
+        libxcb-cursor-dev `
+        libegl1 libxkbcommon0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-keysyms1
+    }
 
     Write-Output 'Installing appimagetool'
     Invoke-WebRequest `
@@ -87,10 +88,17 @@ if (`
   Remove-Item $PSScriptRoot/.upx/$UPXFolderName
 }
 
+# https://github.com/opencv/opencv-python#source-distributions
+# Allows building OpenCV on Windows ARM64 when only sdist is available
+# https://github.com/opencv/opencv-python/issues/1092#issuecomment-2862538656
+$Env:CMAKE_ARGS = '-DBUILD_opencv_dnn=OFF -DENABLE_NEON=OFF'
+
 $prod = if ($Env:GITHUB_JOB -eq 'Build') { '--no-dev' } else { }
 $lock = if ($Env:GITHUB_JOB) { '--locked' } else { }
-Write-Output "Installing Python dependencies with: uv sync $prod $lock"
-uv sync --active $prod $lock
+# Verbose to see sdist progression
+$uvSyncArgs = @('sync', '--verbose', '--active') + $prod + $lock
+Write-Output "Installing Python dependencies with: uv $uvSyncArgs"
+uv @uvSyncArgs
 
 # Don't compile resources on the Build CI job as it'll do so in build script
 if (-not $prod) {

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import sys
 


### PR DESCRIPTION
- Use the env python from shebang
- `uv sync` comment in install.ps1 actually tracks the command
- Move CMAKE_ARGS build fixes from CI to install.ps1
- Avoid auto-running `apt-get` on systems that don't support it
- Ensure CI build does not skip Splash Screen
- Improved forcing uv to pre-download the right Python version on ARM