### PR TITLE
Improve more install scripts and add import smoke tests

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -37,6 +37,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   Pyright:
     runs-on: ${{ matrix.os }}
@@ -55,7 +59,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
       - run: scripts/install.ps1
-        shell: pwsh
       - name: Analysing the code with Pyright
         uses: jakebailey/pyright-action@v3
         with:
@@ -107,9 +110,12 @@ jobs:
               || null }}
       # endregion
       - run: scripts/install.ps1 ${{ matrix.wine-compat }}
-        shell: pwsh
       - run: "scripts/build.ps1 ${{ matrix.wine-compat }}"
-        shell: pwsh
+      - name: Run test suite
+        # pywinctl/pymonctl connect to the X display at import-time, hence xvfb
+        run: >-
+          ${{ startsWith(matrix.os, 'ubuntu') && 'xvfb-run --auto-servernum' || '' }}
+          uv run -m unittest discover --start-directory tests --verbose
       - name: Add empty profile
         run: echo "" > dist/settings.toml
       - name: Extract AutoSplit version
@@ -119,7 +125,6 @@ jobs:
           $Env:AUTOSPLIT_VERSION=uv run python -c "import utils; print(utils.AUTOSPLIT_VERSION)"
           echo "AUTOSPLIT_VERSION=$Env:AUTOSPLIT_VERSION" >> $Env:GITHUB_OUTPUT
           echo "OS=$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)" >> $Env:GITHUB_OUTPUT
-        shell: pwsh
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v6
         with:
@@ -148,7 +153,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Annotate release template URL
-        shell: pwsh
         run: |
           $version = "v${{ needs.Build.outputs.AUTOSPLIT_VERSION }}"
           $body = [uri]::EscapeDataString(((@'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   # Windows-only dependencies:
   "pygrabber >=0.2; sys_platform == 'win32'", # Completed types
   "pywin32 >=312; sys_platform == 'win32'", # Python 3.15 support
-  "typed-D3DShot[numpy] >=1.0.1; sys_platform == 'win32'",
+  "typed-D3DShot[numpy] >=1.1.1; sys_platform == 'win32'",
   # winrt: 3.14 wheels # TODO: Bump when 3.15 wheels
   "winrt-Windows.Foundation >=3.2.1; sys_platform == 'win32'",
   "winrt-Windows.Graphics >=3.2.1; sys_platform == 'win32'",
@@ -80,13 +80,13 @@ find-links = ["./scripts"] # Discover local wheels
 
 exclude-newer = "1 week"
 [tool.uv.exclude-newer-package]
-# package = "3 days" # Reason
+typed-D3DShot = false # I own it
 
 ###
 # Development channels
 ###
 [tool.uv.sources]
-beslogic-ruff-config = { git = "https://github.com/Beslogic/Beslogic-Ruff-Config" }
+beslogic-ruff-config = { git = "https://github.com/Beslogic/Beslogic-Ruff-Config", rev = "312cfab8a1e2653639a2ef665e99eac6c7412ba7" }
 # pywin32 = { git = "https://github.com/mhammond/pywin32.git", marker = "python_version >= '3.15'" }
 # numpy = { index = "scientific-python-nightly-wheels", marker = "python_version >= '3.15'" }
 # pillow = { index = "scientific-python-nightly-wheels", marker = "python_version >= '3.15'" }

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,6 +9,8 @@ ignore = [
   "N999", # pep8-naming: Invalid module name
   # Print are used as debug logs
   "T20", # flake8-print
+  # We use unittest, not pytest
+  "PT", # flake8-pytest-style
   # This is a relatively small, low contributors project. Git blame suffice.
   "TD002", # missing-todo-author
   # We do work in __init__ modules

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -9,11 +9,9 @@ Push-Location "$PSScriptRoot/.." # Avoid issues with space in path
 try {
   & 'scripts/compile_resources.ps1'
 
+  # CI not allowed to skip splash screen, it MUST build (will fail when calling PyInstaller)
   $SupportsSplashScreen = $Env:GITHUB_JOB -or [System.Convert]::ToBoolean(
-    $(uv run --active python -c '
-from PyInstaller.building.splash import Splash
-Splash._check_tcl_tk_compatibility()
-    '))
+    $(uv run --active scripts/check_splash_support.py))
 
   $arguments = @(
     'src/AutoSplit.py',

--- a/scripts/check_splash_support.py
+++ b/scripts/check_splash_support.py
@@ -1,0 +1,19 @@
+"""
+Check whether PyInstaller can build the splash screen on this platform.
+
+Prints "True" or "False" to stdout for consumption by build.ps1.
+"""
+
+# Not found in typeshed because private
+# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false
+
+import sys
+
+from PyInstaller.building.splash import Splash
+
+try:
+    Splash._check_tcl_tk_compatibility()  # noqa: SLF001
+    print(True)
+except SystemExit as e:
+    print(e, file=sys.stderr)
+    print(False)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -109,9 +109,8 @@ $Env:CMAKE_ARGS = '-DBUILD_opencv_dnn=OFF -DENABLE_NEON=OFF'
 
 $prod = if ($Env:GITHUB_JOB -eq 'Build') { '--no-dev' } else { }
 $lock = if ($Env:GITHUB_JOB) { '--locked' } else { }
-$verbose = if ($Env:GITHUB_JOB) { '--verbose' } else { }
 # Verbose to see sdist progression
-$uvSyncArgs = @('sync', '--active') + $prod + $lock + $verbose
+$uvSyncArgs = @('sync', '--active') + $prod + $lock # + '--verbose'
 Write-Output "Installing Python dependencies with: uv $uvSyncArgs"
 uv @uvSyncArgs
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -32,15 +32,29 @@ if ($IsLinux) {
 
 if ($IsLinux) {
   if (-not $Env:GITHUB_JOB -or $Env:GITHUB_JOB -eq 'Build') {
-    if (Get-Command apt-get -ErrorAction SilentlyContinue) {
-      sudo apt-get update
-      # python3-tk for splash screen
-      # libxcb-cursor-dev for QT_QPA_PLATFORM=xcb
-      # the rest for PySide6
-      sudo apt-get install -y `
-        python3-tk `
-        libxcb-cursor-dev `
-        libegl1 libxkbcommon0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-keysyms1
+    # System dependencies
+    if ((Get-Command apt-get, dpkg-query -ErrorAction SilentlyContinue).Count -eq 2) {
+      $packages = @(
+        # For running tests headless on CI
+        ($Env:GITHUB_JOB ? 'xvfb' : $null),
+        # Required by pymonctl at import
+        'x11-xserver-utils',
+        # For splash screen
+        'python3-tk',
+        # For QT_QPA_PLATFORM=xcb
+        'libxcb-cursor-dev',
+        # The rest for PySide6
+        'libegl1', 'libxkbcommon0', 'libxkbcommon-x11-0', 'libxcb-icccm4', 'libxcb-keysyms1'
+      ).Where({ $_ })
+      # Only install missing packages so apt doesn't re-mark them as manually installed.
+      # Multi-arch packages report one status line per architecture.
+      $missing = $packages.Where({
+          @(dpkg-query -W -f='${db:Status-Status}\n' $_ 2>$null) -notcontains 'installed'
+        })
+      if ($missing) {
+        sudo apt-get update
+        sudo apt-get install -y $missing
+      }
     }
 
     Write-Output 'Installing appimagetool'
@@ -95,8 +109,9 @@ $Env:CMAKE_ARGS = '-DBUILD_opencv_dnn=OFF -DENABLE_NEON=OFF'
 
 $prod = if ($Env:GITHUB_JOB -eq 'Build') { '--no-dev' } else { }
 $lock = if ($Env:GITHUB_JOB) { '--locked' } else { }
+$verbose = if ($Env:GITHUB_JOB) { '--verbose' } else { }
 # Verbose to see sdist progression
-$uvSyncArgs = @('sync', '--verbose', '--active') + $prod + $lock
+$uvSyncArgs = @('sync', '--active') + $prod + $lock + $verbose
 Write-Output "Installing Python dependencies with: uv $uvSyncArgs"
 uv @uvSyncArgs
 

--- a/tests/test_import_all_modules.py
+++ b/tests/test_import_all_modules.py
@@ -1,0 +1,63 @@
+"""
+Smoke test: import every one of our own modules, including submodules.
+
+Catches import-time errors early: syntax errors, missing dependencies
+and broken platform guards in module-level code.
+"""
+
+import importlib
+import operator
+import pkgutil
+import sys
+import unittest
+from pathlib import Path
+
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+# Single-platform modules, by the platform they support.
+# Importing one on any other platform is expected to raise OSError.
+PLATFORM_MODULES = {
+    "win32": {
+        "capture_method.BitBltCaptureMethod",
+        "capture_method.DesktopDuplicationCaptureMethod",
+        "capture_method.ForceFullContentRenderingCaptureMethod",
+        "capture_method.WindowsGraphicsCaptureMethod",
+        "d3d11",
+    },
+    "linux": {
+        "capture_method.Screenshot using QT attempt",
+        "capture_method.ScrotCaptureMethod",
+        "capture_method.XcbCaptureMethod",
+    },
+}
+EXPECTED_OS_ERRORS = frozenset(
+    module
+    for platform, modules in PLATFORM_MODULES.items()
+    if platform != sys.platform
+    for module in modules
+)
+
+
+def iter_all_modules():
+    """Yields every top-level module, followed by its direct submodules."""
+    for top_level in sorted(pkgutil.iter_modules([SRC_DIR]), key=operator.attrgetter("name")):
+        yield top_level.name
+        if top_level.ispkg:
+            for submodule in pkgutil.iter_modules([SRC_DIR / top_level.name]):
+                yield f"{top_level.name}.{submodule.name}"
+
+
+class TestImportAllModules(unittest.TestCase):
+    def test_import_all_modules(self):
+        for module_name in iter_all_modules():
+            with self.subTest(module=module_name):
+                if module_name in EXPECTED_OS_ERRORS:
+                    with self.assertRaises(OSError):
+                        importlib.import_module(module_name)
+                else:
+                    importlib.import_module(module_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -6,8 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and platform_machine != 'ARM64' and sys_platform == 'win32'",
 ]
 supported-markers = [
     "sys_platform == 'linux'",
@@ -17,6 +19,9 @@ supported-markers = [
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
+
+[options.exclude-newer-package]
+typed-d3dshot = false
 
 [manifest]
 
@@ -138,7 +143,7 @@ requires-dist = [
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=312" },
     { name = "pywinctl", specifier = ">=0.0.42" },
     { name = "tomli-w", specifier = ">=1.1.0" },
-    { name = "typed-d3dshot", extras = ["numpy"], marker = "sys_platform == 'win32'", specifier = ">=1.0.1" },
+    { name = "typed-d3dshot", extras = ["numpy"], marker = "sys_platform == 'win32'", specifier = ">=1.1.1" },
     { name = "winrt-windows-foundation", marker = "sys_platform == 'win32'", specifier = ">=3.2.1" },
     { name = "winrt-windows-graphics", marker = "sys_platform == 'win32'", specifier = ">=3.2.1" },
     { name = "winrt-windows-graphics-capture", marker = "sys_platform == 'win32'", specifier = ">=3.2.1" },
@@ -151,7 +156,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "beslogic-ruff-config", git = "https://github.com/Beslogic/Beslogic-Ruff-Config" },
+    { name = "beslogic-ruff-config", git = "https://github.com/Beslogic/Beslogic-Ruff-Config?rev=312cfab8a1e2653639a2ef665e99eac6c7412ba7" },
     { name = "dprint-py", specifier = ">=0.50.0.0" },
     { name = "mypy", specifier = ">=2.1" },
     { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.400" },
@@ -164,14 +169,14 @@ dev = [
     { name = "types-pywin32", marker = "sys_platform == 'win32'", specifier = ">=306.0.0.20240130" },
 ]
 ruff = [
-    { name = "beslogic-ruff-config", git = "https://github.com/Beslogic/Beslogic-Ruff-Config" },
+    { name = "beslogic-ruff-config", git = "https://github.com/Beslogic/Beslogic-Ruff-Config?rev=312cfab8a1e2653639a2ef665e99eac6c7412ba7" },
     { name = "ruff" },
 ]
 
 [[package]]
 name = "beslogic-ruff-config"
-version = "1.0.1"
-source = { git = "https://github.com/Beslogic/Beslogic-Ruff-Config#dd94f26b1de7234195d1a52cc3f9e6ac65b8ca51" }
+version = "1.1.0"
+source = { git = "https://github.com/Beslogic/Beslogic-Ruff-Config?rev=312cfab8a1e2653639a2ef665e99eac6c7412ba7#312cfab8a1e2653639a2ef665e99eac6c7412ba7" }
 dependencies = [
     { name = "ruff", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -528,8 +533,10 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and platform_machine != 'ARM64' and sys_platform == 'win32'",
 ]
 dependencies = [
     { name = "shiboken6", version = "6.9.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or sys_platform == 'win32'" },
@@ -671,8 +678,10 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and platform_machine != 'ARM64' and sys_platform == 'win32'",
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/07/53b2532ecd42ff925feb06b7bb16917f5f99f9c3470f0815c256789d818b/shiboken6-6.9.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:efcdfa8655d34aaf8d7a0c7724def3440bd46db02f5ad3b1785db5f6ccb0a8ff", size = 206756, upload-time = "2025-06-03T13:16:46.528Z" },
@@ -701,14 +710,14 @@ wheels = [
 
 [[package]]
 name = "typed-d3dshot"
-version = "1.0.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "comtypes", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/05/faad24e43db0333df99ad93cf4472702d4bfcb2bc7d946186a312f1fe3b8/typed_d3dshot-1.0.1.tar.gz", hash = "sha256:7cf3fb6304bfde82d9a279c16fd5798100e035f3ac9f53b82a9bec718d84bb29", size = 33913, upload-time = "2024-10-09T20:43:29.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/e8/c1d050bd5d71ba7eab613677bfafe7e43b50dcf10a7698e331231049e5f4/typed_d3dshot-1.1.1.tar.gz", hash = "sha256:c1f3acc984ad1eeb6b3199153ffe0d585f57007195a03d1b9222e9324d2fcfc5", size = 25013, upload-time = "2026-06-13T05:25:05.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/23/bafe1f74835ff57efc8b8bbdec95e3a5d5e4316f17c51616fb33aeaa24f2/typed_d3dshot-1.0.1-py3-none-any.whl", hash = "sha256:775cbb476535d98fb0bdc99b21d247af44957608a38bd1f6b5de7da74a2a991f", size = 33511, upload-time = "2024-10-09T20:43:27.779Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bd/85db9d8ec0bc5bdf2c70867c121a4e3e26e4da15659bd352d991659201a7/typed_d3dshot-1.1.1-py3-none-any.whl", hash = "sha256:be4a1c0194047ad618c9d417a07cd5f8fea105fc6ea8930ba037f37bb144d01f", size = 33239, upload-time = "2026-06-13T05:25:04.25Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
- New smoke import tests
- install.ps1: only apt-get install missing packages so apt doesn't re-mark them as manually installed
- build.ps1: extract splash screen probe into scripts/check_splash_support.py
- Default workflow shell to pwsh
- Updated typed-D3DShot
  - Fixed crash on Windows ARM64 trying to initialize D3D Desktop Duplication