### PR TITLE
Fix 'Do not ask again' update checker checkbox being inverted

### DIFF
--- a/src/menu_bar.py
+++ b/src/menu_bar.py
@@ -100,7 +100,7 @@ class __UpdateCheckerWidget(QtWidgets.QWidget, update_checker.Ui_UpdateChecker):
     def do_not_ask_me_again_state_changed(self):
         user_profile.set_check_for_updates_on_open(
             self.design_window,
-            self.do_not_ask_again_checkbox.isChecked(),
+            not self.do_not_ask_again_checkbox.isChecked(),
         )
 
 


### PR DESCRIPTION
The 'Do not ask again' checkbox functionality is currently inverted.
Checking the checkbox turns the update checker on (which is also default), and it will only actually disable the update checker if you uncheck it again after checking it. It essentially does nothing when you check it, and then does what you expect from "checked" behavior when you uncheck it again.