### PR TITLE
Bump minimum Ubuntu to 24.04, glibc 2.39 (Fix broken Linux AppImage due to symbol-table strip)

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       # Only the Python version we plan on shipping matters.
       matrix:
-        os: [windows-latest, windows-11-arm, ubuntu-22.04, ubuntu-24.04-arm]
+        os: [windows-latest, windows-11-arm, ubuntu-24.04, ubuntu-24.04-arm]
         python-version: ["3.14"]
         wine-compat: [""]
         include:

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ To understand how to use AutoSplit and how it works in-depth, please read the [t
 - Wine 10.1+ ([very limited](#wine-limitations))
   - Useful if you want to use Desktop version of LiveSplit on Linux
 - Linux
-  - Should work on Ubuntu 22.04+ for x64 devices, Ubuntu 24.04+ for ARM64 devices
+  - Should work on Ubuntu 24.04+ (tested on Kubuntu 26.04)
   - Wayland is not currently supported
   - WSL2/WSLg requires an additional Desktop Environment, external X11 server, and/or systemd
-- x64 and ARM64 architectures \* (see [Known Limitations](#known-limitations) for ARM64)
+- x64 and ARM64 architectures
+  - Native ARM64 builds go completely untested. There may be unforeseen issues.
 - If you'd like to run the project directly in Python from the source code, refer to the [build instructions](/docs/build%20instructions.md).
 
 ## Timer Integration
@@ -78,7 +79,6 @@ Linux users, note that LiveSplit Desktop, with additional components, is only av
 - Linux support has feature-parity but is less performant. We're [looking for contributors](../../issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted"+label%3ALinux+).
   - Incompatible with LiveSplitOne on Linux (see <https://github.com/LiveSplit/LiveSplitOne/issues/1025>)
 - Antivirus false positives. Please read <https://github.com/pyinstaller/pyinstaller/blob/develop/.github/ISSUE_TEMPLATE/antivirus.md>
-- Native ARM64 builds go completely untested. There may be unforeseen issues.
 
 ### Wine Limitations
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To understand how to use AutoSplit and how it works in-depth, please read the [t
 - Wine 10.1+ ([very limited](#wine-limitations))
   - Useful if you want to use Desktop version of LiveSplit on Linux
 - Linux
-  - Should work on Ubuntu 24.04+ (tested on Kubuntu 26.04)
+  - Should work on Ubuntu 24.04+ (glibc 2.39) (tested on Kubuntu 26.04)
   - Wayland is not currently supported
   - WSL2/WSLg requires an additional Desktop Environment, external X11 server, and/or systemd
 - x64 and ARM64 architectures

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -22,8 +22,13 @@ try {
     '--additional-hooks-dir=Pyinstaller/hooks',
     "--add-data=pyproject.toml$([System.IO.Path]::PathSeparator).",
     '--icon=res/icon.ico')
-  if (-not $WineCompat) {
+  # Don't UPX compress if trying to be Wine Compatible, or on Linux (handled manually below)
+  if (-not $WineCompat -and -not $IsLinux) {
     $arguments += '--upx-dir=scripts/.upx'
+  }
+  else {
+    # Missing upx executable should be enough, but let's be explicit
+    $arguments += '--noupx'
   }
   if ($SupportsSplashScreen) {
     # https://github.com/pyinstaller/pyinstaller/issues/9022
@@ -43,7 +48,7 @@ try {
       '--strip')
   }
 
-  Write-Output $arguments
+  Write-Output "pyinstaller $($arguments -join ' ')"
   & uv run --active pyinstaller @arguments
 
   if ($IsLinux) {

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -65,7 +65,7 @@ IMREAD_EXT_FILTER = (
 def get_top_window_at(x: int, y: int):
     """Give QWidget time to disappear to avoid Xlib.error.BadDrawable on Linux."""
     if sys.platform == "linux":
-        # Tested in increments of 10ms on my Pop!_OS 22.04 VM
+        # 80ms was the minimum needed when tested in increments of 10ms on my Pop!_OS 22.04 VM
         QTest.qWait(80)
     return getTopWindowAt(x, y)
 


### PR DESCRIPTION
See https://github.com/pyinstaller/pyinstaller/issues/9463#issuecomment-4734871559