### PR TITLE
Added a live logging window

### DIFF
--- a/res/design.ui
+++ b/res/design.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>786</width>
-    <height>450</height>
+    <height>700</height>
    </rect>
   </property>
   <property name="minimumSize">

--- a/res/design.ui
+++ b/res/design.ui
@@ -527,6 +527,9 @@
       <height>22</height>
      </rect>
     </property>
+    <property name="text">
+     <string>No Folder Selected</string>
+    </property>
     <property name="readOnly">
      <bool>true</bool>
     </property>
@@ -953,13 +956,23 @@
    <addaction name="menu_help"/>
   </widget>
   <widget class="QStatusBar" name="status_bar">
+   <property name="styleSheet">
+    <string notr="true">QStatusBar { border-top: 1px solid palette(mid); }
+ClickableLabel { padding: 1px 16px 1px 6px; }
+ClickableLabel:hover { background-color: palette(midlight); }</string>
+   </property>
    <property name="sizeGripEnabled">
     <bool>false</bool>
    </property>
-   <property name="styleSheet">
-    <string notr="true">QStatusBar { border-top: 1px solid palette(mid); }</string>
-   </property>
    <widget class="ClickableLabel" name="log_footer_label">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>100</width>
+      <height>30</height>
+     </rect>
+    </property>
     <property name="sizePolicy">
      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
       <horstretch>1</horstretch>
@@ -987,13 +1000,13 @@
    <widget class="QWidget" name="log_dock_contents">
     <layout class="QVBoxLayout" name="log_dock_layout">
      <property name="leftMargin">
-      <number>0</number>
+      <number>3</number>
      </property>
      <property name="topMargin">
       <number>0</number>
      </property>
      <property name="rightMargin">
-      <number>0</number>
+      <number>3</number>
      </property>
      <property name="bottomMargin">
       <number>0</number>

--- a/res/design.ui
+++ b/res/design.ui
@@ -35,7 +35,22 @@
    <iconset resource="resources.qrc">
     <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
   </property>
+  <property name="styleSheet">
+   <string notr="true">QMainWindow::separator { height: 0px; width: 0px; }</string>
+  </property>
   <widget class="QWidget" name="central_widget">
+   <property name="minimumSize">
+    <size>
+     <width>0</width>
+     <height>404</height>
+    </size>
+   </property>
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>404</height>
+    </size>
+   </property>
    <widget class="QLabel" name="x_label">
     <property name="geometry">
      <rect>
@@ -938,6 +953,12 @@
    <addaction name="menu_help"/>
   </widget>
   <widget class="QStatusBar" name="status_bar">
+   <property name="sizeGripEnabled">
+    <bool>false</bool>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">QStatusBar { border-top: 1px solid palette(mid); }</string>
+   </property>
    <widget class="ClickableLabel" name="log_footer_label">
     <property name="sizePolicy">
      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">

--- a/res/design.ui
+++ b/res/design.ui
@@ -927,7 +927,14 @@
     <addaction name="action_save_profile_as"/>
     <addaction name="action_load_profile"/>
    </widget>
+   <widget class="QMenu" name="menu_view">
+    <property name="title">
+     <string>View</string>
+    </property>
+    <addaction name="action_toggle_logs"/>
+   </widget>
    <addaction name="menu_file"/>
+   <addaction name="menu_view"/>
    <addaction name="menu_help"/>
   </widget>
   <widget class="QStatusBar" name="status_bar">
@@ -1079,6 +1086,17 @@
    </property>
    <property name="menuRole">
     <enum>QAction::MenuRole::AboutQtRole</enum>
+   </property>
+  </action>
+  <action name="action_toggle_logs">
+   <property name="text">
+    <string>Toggle Logs</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
   </action>
  </widget>

--- a/res/design.ui
+++ b/res/design.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>786</width>
-    <height>700</height>
+    <height>598</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -20,7 +20,7 @@
   <property name="maximumSize">
    <size>
     <width>786</width>
-    <height>720</height>
+    <height>598</height>
    </size>
   </property>
   <property name="font">
@@ -988,11 +988,15 @@ ClickableLabel:hover { background-color: palette(midlight); }</string>
    </widget>
   </widget>
   <widget class="QDockWidget" name="log_dock">
+   <property name="styleSheet">
+    <string notr="true">QDockWidget::title { padding: 6px;  }</string>
+   </property>
    <property name="features">
     <set>QDockWidget::DockWidgetFeature::NoDockWidgetFeatures</set>
    </property>
    <property name="windowTitle">
-    <string>Log</string>
+    <string>1 (docker header can't be hidden in editor, removed at runtime)
+2 (line count height is approximate, making header appear about 2 lines)</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>8</number>
@@ -1013,8 +1017,24 @@ ClickableLabel:hover { background-color: palette(midlight); }</string>
      </property>
      <item>
       <widget class="QPlainTextEdit" name="log_history_view">
+       <property name="font">
+        <font>
+         <family>monospace</family>
+        </font>
+       </property>
        <property name="readOnly">
         <bool>true</bool>
+       </property>
+       <property name="plainText">
+        <string>3
+4
+5
+6
+7
+8
+9
+10
+11</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>

--- a/res/design.ui
+++ b/res/design.ui
@@ -8,19 +8,19 @@
     <x>0</x>
     <y>0</y>
     <width>786</width>
-    <height>426</height>
+    <height>450</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>786</width>
-    <height>426</height>
+    <height>450</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>786</width>
-    <height>426</height>
+    <height>720</height>
    </size>
   </property>
   <property name="font">
@@ -930,6 +930,59 @@
    <addaction name="menu_file"/>
    <addaction name="menu_help"/>
   </widget>
+  <widget class="QStatusBar" name="status_bar">
+   <widget class="ClickableLabel" name="log_footer_label">
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <horstretch>1</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="toolTip">
+     <string>Last log message. Click to show the full log.</string>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="log_dock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFeature::NoDockWidgetFeatures</set>
+   </property>
+   <property name="windowTitle">
+    <string>Log</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="log_dock_contents">
+    <layout class="QVBoxLayout" name="log_dock_layout">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPlainTextEdit" name="log_history_view">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
   <action name="action_view_help">
    <property name="text">
     <string>View Help</string>
@@ -1029,6 +1082,13 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ClickableLabel</class>
+   <extends>QLabel</extends>
+   <header>log_capture</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>split_image_folder_input</tabstop>
   <tabstop>x_spinbox</tabstop>

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -327,7 +327,10 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             self._append_log_line(log_line)
         if history:
             self._update_log_footer(history[-1])
-        log_capture.LOG_EMITTER.line_logged.connect(self._on_log_line)
+        # Each live line goes into the panel and updates the footer
+        # (append first, so the footer's single-line preview reflects the line that was just added).
+        log_capture.LOG_EMITTER.line_logged.connect(self._append_log_line)
+        log_capture.LOG_EMITTER.line_logged.connect(self._update_log_footer)
 
         # Restore the panel's last expanded/collapsed state.
         self._set_log_panel_visible(
@@ -376,11 +379,6 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         stderr_color = f"color: {LOG_STDERR_COLOR.name()};" if is_stderr else ""
         self.log_footer_label.setStyleSheet(stderr_color)
         self.log_footer_label.set_elided_text(f"{chevron}  {timestamp} {first_line}")
-
-    @QtCore.Slot(str, str, bool)
-    def _on_log_line(self, *log_line: *log_capture.LogLine):
-        self._append_log_line(log_line)
-        self._update_log_footer(log_line)
 
     def __browse(self):
         # User selects the file with the split images in it.

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -158,6 +158,9 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
     # Last (timestamp, text, is_stderr) shown in the footer, kept so it can be re-rendered.
     _last_footer_entry: tuple[str, str, bool] | None = None
 
+    # Window height with the log panel collapsed; captured from the .ui to fix the height per state.
+    _collapsed_height = 0
+
     def __init__(self):  # noqa: PLR0915
         super().__init__()
 
@@ -318,6 +321,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
 
     def _setup_log_footer(self):
         """Wire up the clickable log footer and the expandable log history panel."""
+        self._collapsed_height = self.minimumHeight()
         # The status bar doesn't add() its .ui child, and stretch isn't expressible there.
         self.status_bar.addWidget(self.log_footer_label, 1)
         self.status_bar.setContentsMargins(0, 0, 0, 0)  # Let the label's padding define the insets.
@@ -340,7 +344,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
 
     def _set_log_panel_visible(self, show: bool):  # noqa: FBT001 # boolean value setter, not an arbitrary flag
         self.log_dock.setVisible(show)
-        self.resize(self.width(), self.minimumHeight() + (LOG_PANEL_HEIGHT if show else 0))
+        # Fix the height per state so it can't be dragged to over-expand or hide content.
+        self.setFixedHeight(self._collapsed_height + (LOG_PANEL_HEIGHT if show else 0))
         self._refresh_log_footer()  # Flip the chevron to match the new state.
 
     def _toggle_log_panel(self):

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -320,6 +320,10 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         self.status_bar.setContentsMargins(0, 0, 0, 0)  # Let the label's padding define the insets.
         # An empty title bar (collapses to no height) makes the dock read as an inline panel.
         self.log_dock.setTitleBarWidget(QWidget())
+        # Monospace so timestamps and indented continuation lines align (system fixed-width font).
+        self.log_history_view.setFont(
+            QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
+        )
         self.log_footer_label.clicked.connect(self._toggle_log_panel)
 
         # Surface anything already logged (e.g. the version/PID line) before connecting live.
@@ -354,7 +358,9 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             char_format.setForeground(LOG_STDERR_COLOR)
         # Newline before each entry (not after) so there is no trailing blank line.
         prefix = "" if self.log_history_view.document().isEmpty() else "\n"
-        cursor.insertText(f"{prefix}{timestamp} {text}", char_format)
+        # Align a multi-line entry's continuation lines under the text (past the timestamp).
+        body = text.replace("\n", "\n" + " " * (len(timestamp) + 1))
+        cursor.insertText(f"{prefix}{timestamp} {body}", char_format)
         scrollbar = self.log_history_view.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import sys
 import warnings
 
@@ -120,6 +121,13 @@ LOG_FOOTER_STYLE = """
 ClickableLabel {{ padding: 1px 16px 1px 6px; color: {color}; }}
 ClickableLabel:hover {{ background-color: palette(midlight); }}
 """
+_LOG_LOCATION_PREFIX = re.compile(r"^\S+:\d+:\s+")
+"""Matches a leading ``path:lineno:`` (e.g. from a warning) to drop it from the footer preview."""
+
+
+def _footer_preview(text: str) -> str:
+    """First line of an (already-relativized) entry; drops a leading ``path:lineno:`` prefix."""
+    return _LOG_LOCATION_PREFIX.sub("", text.split("\n", 1)[0])
 
 
 class AutoSplit(QMainWindow, design.Ui_MainWindow):
@@ -330,11 +338,10 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
 
         # Surface anything already logged (e.g. the version/PID line) before connecting live.
         history = log_capture.LOG_EMITTER.history()
-        for timestamp, text, is_stderr in history:
-            self._append_log_line(timestamp, text, is_stderr=is_stderr)
+        for log_line in history:
+            self._append_log_line(log_line)
         if history:
-            last_timestamp, last_text, last_is_stderr = history[-1]
-            self._update_log_footer(last_timestamp, last_text, is_stderr=last_is_stderr)
+            self._update_log_footer(history[-1])
         log_capture.LOG_EMITTER.line_logged.connect(self._on_log_line)
 
         # Restore the panel's last expanded/collapsed state.
@@ -351,7 +358,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         self._set_log_panel_visible(not self.log_dock.isVisible())
         user_profile.QT_SETTINGS.setValue("log_panel_visible", self.log_dock.isVisible())
 
-    def _append_log_line(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001 # is_stderr is intrinsic line data, not an arbitrary boolean flag
+    def _append_log_line(self, log_line: log_capture.LogLine):
+        timestamp, text, is_stderr = log_line
         cursor = self.log_history_view.textCursor()
         cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
         char_format = QtGui.QTextCharFormat()
@@ -363,16 +371,16 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         scrollbar = self.log_history_view.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 
-    def _update_log_footer(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001 # is_stderr is intrinsic line data, not an arbitrary boolean flag
-        self._last_footer_entry = (timestamp, text, is_stderr)
+    def _update_log_footer(self, log_line: log_capture.LogLine):
+        self._last_footer_entry = log_line
         self._refresh_log_footer()
 
     def _refresh_log_footer(self):
         if self._last_footer_entry is None:
             return
         timestamp, text, is_stderr = self._last_footer_entry
-        # The footer is a single line; show the timestamp and first line of (multi-line) entries.
-        first_line = text.split("\n", 1)[0]
+        # Footer is single-line and shows the message directly (no path prefix).
+        first_line = _footer_preview(text)
         # Footer affordances hinting it expands a log panel: a chevron and hover/border styling.
         chevron = "▲" if self.log_dock.isVisible() else "▶"
         color = LOG_STDERR_COLOR.name() if is_stderr else "palette(text)"
@@ -380,9 +388,9 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         self.log_footer_label.set_elided_text(f"{chevron}  {timestamp} {first_line}")
 
     @QtCore.Slot(str, str, bool)
-    def _on_log_line(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001 # is_stderr is intrinsic line data, not an arbitrary boolean flag
-        self._append_log_line(timestamp, text, is_stderr)
-        self._update_log_footer(timestamp, text, is_stderr)
+    def _on_log_line(self, *log_line: *log_capture.LogLine):
+        self._append_log_line(log_line)
+        self._update_log_footer(log_line)
 
     def __browse(self):
         # User selects the file with the split images in it.

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -33,6 +33,14 @@ if sys.platform == "linux":
     # os.environ.setdefault("QT_DEBUG_PLUGINS", "1")
 
 # ruff: disable[E402] # https://github.com/astral-sh/ruff/issues/21423
+# Tee stdout/stderr before the heavy imports below, so import-time warnings and errors
+# (e.g. Xlib ResourceWarnings) are mirrored to the log footer too. This must run after the
+# platform-specific setup above (which has to happen before any Qt import) but before
+# cv2/PySide6/capture_method are imported.
+import log_capture
+
+log_capture.install()
+
 import signal
 from collections.abc import Callable
 from copy import deepcopy
@@ -43,7 +51,7 @@ from typing import TYPE_CHECKING, NoReturn, cast, override
 import cv2
 from PySide6 import QtCore, QtGui
 from PySide6.QtTest import QTest
-from PySide6.QtWidgets import QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox
+from PySide6.QtWidgets import QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox, QWidget
 
 import error_messages
 import user_profile
@@ -100,6 +108,19 @@ if TYPE_CHECKING:
 
 CHECK_FPS_ITERATIONS = 10
 
+MAIN_CONTENT_HEIGHT = 404
+"""Fixed height of the main (absolutely-laid-out) content, so the expandable log panel grows the
+window downward instead of squashing it. Matches the window's collapsed minimum minus the
+menu and status bars."""
+LOG_PANEL_HEIGHT = 250
+"""How tall the expandable log history panel is when shown."""
+LOG_STDERR_COLOR = QtGui.QColor("#c0392b")
+"""Color for log lines that came from stderr (warnings, errors, tracebacks)."""
+LOG_FOOTER_STYLE = """
+ClickableLabel {{ padding: 1px 16px 1px 6px; color: {color}; }}
+ClickableLabel:hover {{ background-color: palette(midlight); }}
+"""
+
 
 class AutoSplit(QMainWindow, design.Ui_MainWindow):
     # Parse command line args
@@ -129,6 +150,9 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
     UpdateCheckerWidget: update_checker.Ui_UpdateChecker | None = None
     CheckForUpdatesThread: QtCore.QThread | None = None
     SettingsWidget: settings.Ui_SettingsWidget | None = None
+
+    # Last (timestamp, text, is_stderr) shown in the footer, kept so it can be re-rendered.
+    _last_footer_entry: tuple[str, str, bool] | None = None
 
     def __init__(self):  # noqa: PLR0915
         super().__init__()
@@ -173,6 +197,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             f"AutoSplit v{AUTOSPLIT_VERSION}"
             + (" (externally controlled)" if self.is_auto_controlled else "")
         )
+        self._setup_log_footer()
 
         # Hotkeys need to be initialized to be passed as thread arguments in hotkeys.py
         for hotkey in HOTKEYS:
@@ -285,6 +310,71 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             check_for_updates(self, check_on_open=True)
 
     # FUNCTIONS
+
+    def _setup_log_footer(self):
+        """Wire up the clickable log footer and the expandable log history panel."""
+        # Pin the main content so the log panel grows the window downward rather than squashing it.
+        self.central_widget.setFixedHeight(MAIN_CONTENT_HEIGHT)
+        # Place the footer label so it fills the status bar and is the click target. A top border
+        # and dropped size grip make the footer read as its own clearly-defined, clickable strip.
+        self.status_bar.addWidget(self.log_footer_label, 1)
+        self.status_bar.setSizeGripEnabled(False)
+        self.status_bar.setContentsMargins(0, 0, 0, 0)  # Let the label's padding define the insets.
+        self.status_bar.setStyleSheet("QStatusBar { border-top: 1px solid palette(mid); }")
+        # Make the dock read as an inline panel: no title bar, hidden until the footer is clicked.
+        title_spacer = QWidget()
+        title_spacer.setFixedHeight(0)  # Hide draggable separator
+        self.log_dock.setTitleBarWidget(title_spacer)
+        self.setStyleSheet("QMainWindow::separator { height: 0px; width: 0px; }")
+        self.log_dock.hide()
+        self.log_footer_label.clicked.connect(self._toggle_log_panel)
+
+        # Surface anything already logged (e.g. the version/PID line) before connecting live.
+        history = log_capture.LOG_EMITTER.history()
+        for timestamp, text, is_stderr in history:
+            self._append_log_line(timestamp, text, is_stderr=is_stderr)
+        if history:
+            self._update_log_footer(*history[-1])
+        log_capture.LOG_EMITTER.line_logged.connect(self._on_log_line)
+
+    def _toggle_log_panel(self):
+        show = not self.log_dock.isVisible()
+        self.log_dock.setVisible(show)
+        self.resize(self.width(), self.minimumHeight() + (LOG_PANEL_HEIGHT if show else 0))
+        self._refresh_log_footer()  # Flip the chevron to match the new state.
+
+    def _append_log_line(self, timestamp: str, text: str, *, is_stderr: bool):
+        cursor = self.log_history_view.textCursor()
+        cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
+        char_format = QtGui.QTextCharFormat()
+        if is_stderr:
+            char_format.setForeground(LOG_STDERR_COLOR)
+        # Newline before each entry (not after) so there is no trailing blank line.
+        prefix = "" if self.log_history_view.document().isEmpty() else "\n"
+        cursor.insertText(f"{prefix}{timestamp} {text}", char_format)
+        scrollbar = self.log_history_view.verticalScrollBar()
+        scrollbar.setValue(scrollbar.maximum())
+
+    def _update_log_footer(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001
+        self._last_footer_entry = (timestamp, text, is_stderr)
+        self._refresh_log_footer()
+
+    def _refresh_log_footer(self):
+        if self._last_footer_entry is None:
+            return
+        timestamp, text, is_stderr = self._last_footer_entry
+        # The footer is a single line; show the timestamp and first line of (multi-line) entries.
+        first_line = text.split("\n", 1)[0]
+        # Footer affordances hinting it expands a log panel: a chevron and hover/border styling.
+        chevron = "▲" if self.log_dock.isVisible() else "▶"
+        color = LOG_STDERR_COLOR.name() if is_stderr else "palette(text)"
+        self.log_footer_label.setStyleSheet(LOG_FOOTER_STYLE.format(color=color))
+        self.log_footer_label.set_elided_text(f"{chevron}  {timestamp} {first_line}")
+
+    @QtCore.Slot(str, str, bool)
+    def _on_log_line(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001
+        self._append_log_line(timestamp, text, is_stderr=is_stderr)
+        self._update_log_footer(timestamp, text, is_stderr)
 
     def __browse(self):
         # User selects the file with the split images in it.

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -317,13 +317,12 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         self.status_bar.setContentsMargins(0, 0, 0, 0)  # Let the label's padding define the insets.
         # An empty title bar (collapses to no height) makes the dock read as an inline panel.
         self.log_dock.setTitleBarWidget(QWidget())
-        # Monospace so timestamps and indented continuation lines align (system fixed-width font).
-        self.log_history_view.setFont(
+        self.log_history_view.setFont(  # Use the system's monospace font.
             QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
         )
         self.log_footer_label.clicked.connect(self._toggle_log_panel)
 
-        # Surface anything already logged (e.g. the version/PID line) before connecting live.
+        # Include logs already emitted before connecting live.
         history = log_capture.LOG_EMITTER.history()
         for log_line in history:
             self._append_log_line(log_line)

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -34,10 +34,9 @@ if sys.platform == "linux":
     # os.environ.setdefault("QT_DEBUG_PLUGINS", "1")
 
 # ruff: disable[E402] # https://github.com/astral-sh/ruff/issues/21423
-# Tee stdout/stderr before the heavy imports below, so import-time warnings and errors
-# (e.g. Xlib ResourceWarnings) are mirrored to the log footer too. This must run after the
-# platform-specific setup above (which has to happen before any Qt import) but before
-# cv2/PySide6/capture_method are imported.
+
+# Tee stdout/stderr as soon as possible, so import-time warnings and errors are also caught.
+# This must run after the platform-specific setup above (which has to happen before any Qt import).
 import log_capture
 
 log_capture.install()
@@ -112,9 +111,10 @@ CHECK_FPS_ITERATIONS = 10
 LOG_PANEL_HEIGHT = 250
 """How tall the expandable log history panel is when shown."""
 LOG_STDERR_COLOR = QtGui.QColor("#c0392b")
-"""Color for log lines that came from stderr (warnings, errors, tracebacks)."""
-_LOG_LOCATION_PREFIX = re.compile(r"^\S+:\d+:\s+")
-"""Matches a leading ``path:lineno:`` (e.g. from a warning) to drop it from the footer preview."""
+"""Color for log lines that came from stderr (warnings, errors, tracebacks).
+Source: Pomegranate from https://flatuicolors.com/palette/defo"""
+LOG_LOCATION_PREFIX_RE = re.compile(r"^\S+:\d+:\s+")
+"""Matches a leading `path:lineno:` (e.g. from a warning) to drop it from the footer preview."""
 
 
 class AutoSplit(QMainWindow, design.Ui_MainWindow):
@@ -149,8 +149,10 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
     _last_footer_entry: log_capture.LogLine | None = None
     """Last (timestamp, text, is_stderr) shown in the footer, kept so it can be re-rendered."""
 
-    # Window height with the log panel collapsed; captured from the .ui to fix the height per state.
     _collapsed_height = 0
+    """
+    Window height with the log panel collapsed; captured from the .ui to fix the height per state.
+    """
 
     def __init__(self):  # noqa: PLR0915
         super().__init__()
@@ -371,8 +373,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             return
         timestamp, text, is_stderr = self._last_footer_entry
         # Footer is single-line and shows the message directly (no path prefix).
-        # First line of an (already-relativized) entry; drops a leading ``path:lineno:`` prefix.
-        first_line = _LOG_LOCATION_PREFIX.sub("", text.split("\n", 1)[0])
+        # First line of an (already-relativized) entry; drops a leading `path:lineno:` prefix.
+        first_line = LOG_LOCATION_PREFIX_RE.sub("", text.split("\n", 1)[0])
         # Footer affordances hinting it expands a log panel: a chevron and hover/border styling.
         # Not using isVisible()) as it's incorrect during startup restore, before window is shown
         chevron = "▶" if self.log_dock.isHidden() else "▲"

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -113,10 +113,6 @@ LOG_PANEL_HEIGHT = 250
 """How tall the expandable log history panel is when shown."""
 LOG_STDERR_COLOR = QtGui.QColor("#c0392b")
 """Color for log lines that came from stderr (warnings, errors, tracebacks)."""
-LOG_FOOTER_STYLE = """
-ClickableLabel {{ padding: 1px 16px 1px 6px; color: {color}; }}
-ClickableLabel:hover {{ background-color: palette(midlight); }}
-"""
 _LOG_LOCATION_PREFIX = re.compile(r"^\S+:\d+:\s+")
 """Matches a leading ``path:lineno:`` (e.g. from a warning) to drop it from the footer preview."""
 
@@ -227,9 +223,6 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             # Use and Start the thread that checks for updates from LiveSplit
             self.update_auto_control = AutoControlledThread(self)
             self.update_auto_control.start()
-
-        # split image folder line edit text
-        self.split_image_folder_input.setText("No Folder Selected")
 
         # Connecting menu actions
         self.action_toggle_logs.triggered.connect(self._toggle_log_panel)
@@ -378,8 +371,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         # Footer affordances hinting it expands a log panel: a chevron and hover/border styling.
         # Not using isVisible()) as it's incorrect during startup restore, before window is shown
         chevron = "▶" if self.log_dock.isHidden() else "▲"
-        color = LOG_STDERR_COLOR.name() if is_stderr else "palette(text)"
-        self.log_footer_label.setStyleSheet(LOG_FOOTER_STYLE.format(color=color))
+        stderr_color = f"color: {LOG_STDERR_COLOR.name()};" if is_stderr else ""
+        self.log_footer_label.setStyleSheet(stderr_color)
         self.log_footer_label.set_elided_text(f"{chevron}  {timestamp} {first_line}")
 
     @QtCore.Slot(str, str, bool)

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -108,8 +108,6 @@ if TYPE_CHECKING:
 
 CHECK_FPS_ITERATIONS = 10
 
-LOG_PANEL_HEIGHT = 250
-"""How tall the expandable log history panel is when shown."""
 LOG_STDERR_COLOR = QtGui.QColor("#c0392b")
 """Color for log lines that came from stderr (warnings, errors, tracebacks).
 Source: Pomegranate from https://flatuicolors.com/palette/defo"""
@@ -145,14 +143,6 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
     UpdateCheckerWidget: update_checker.Ui_UpdateChecker | None = None
     CheckForUpdatesThread: QtCore.QThread | None = None
     SettingsWidget: settings.Ui_SettingsWidget | None = None
-
-    _last_footer_entry: log_capture.LogLine | None = None
-    """Last (timestamp, text, is_stderr) shown in the footer, kept so it can be re-rendered."""
-
-    _collapsed_height = 0
-    """
-    Window height with the log panel collapsed; captured from the .ui to fix the height per state.
-    """
 
     def __init__(self):  # noqa: PLR0915
         super().__init__()
@@ -309,9 +299,24 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
 
     # FUNCTIONS
 
+    # region Log footer panel
+    _last_log_footer_entry: log_capture.LogLine | None = None
+    """Last (timestamp, text, is_stderr) shown in the footer, kept so it can be re-rendered."""
+
+    _collapsed_height = 0
+    """
+    Window height with the log panel collapsed; captured from the .ui to fix the height per state.
+    """
+
+    _log_panel_height = 0
+    """Window growth when the panel opens; derived from the .ui (expanded - collapsed height)."""
+
     def _setup_log_footer(self):
         """Wire up the clickable log footer and the expandable log history panel."""
+        # Both come from the .ui: collapsed = minimumSize height, panel = designed (expanded)
+        # geometry height minus that. Captured before setFixedHeight() overwrites minimumHeight().
         self._collapsed_height = self.minimumHeight()
+        self._log_panel_height = self.height() - self._collapsed_height
         # The status bar doesn't add() its .ui child, and stretch isn't expressible there.
         self.status_bar.addWidget(self.log_footer_label, 1)
         self.status_bar.setContentsMargins(0, 0, 0, 0)  # Let the label's padding define the insets.
@@ -320,6 +325,9 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         self.log_history_view.setFont(  # Use the system's monospace font.
             QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
         )
+        # Drop the .ui's Designer-only placeholders (kept there as layout/line-count notes).
+        self.log_history_view.clear()
+        self.log_dock.setWindowTitle("")
         self.log_footer_label.clicked.connect(self._toggle_log_panel)
 
         # Include logs already emitted before connecting live.
@@ -341,7 +349,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
     def _set_log_panel_visible(self, show: bool):  # noqa: FBT001 # boolean value setter, not an arbitrary flag
         self.log_dock.setVisible(show)
         # Fix the height per state so it can't be dragged to over-expand or hide content.
-        self.setFixedHeight(self._collapsed_height + (LOG_PANEL_HEIGHT if show else 0))
+        self.setFixedHeight(self._collapsed_height + (self._log_panel_height if show else 0))
         self._refresh_log_footer()  # Flip the chevron to match the new state.
 
     def _toggle_log_panel(self):
@@ -364,13 +372,13 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         scrollbar.setValue(scrollbar.maximum())
 
     def _update_log_footer(self, log_line: log_capture.LogLine):
-        self._last_footer_entry = log_line
+        self._last_log_footer_entry = log_line
         self._refresh_log_footer()
 
     def _refresh_log_footer(self):
-        if self._last_footer_entry is None:
+        if self._last_log_footer_entry is None:
             return
-        timestamp, text, is_stderr = self._last_footer_entry
+        timestamp, text, is_stderr = self._last_log_footer_entry
         # Footer is single-line and shows the message directly (no path prefix).
         # First line of an (already-relativized) entry; drops a leading `path:lineno:` prefix.
         first_line = LOG_LOCATION_PREFIX_RE.sub("", text.split("\n", 1)[0])
@@ -380,6 +388,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         stderr_color = f"color: {LOG_STDERR_COLOR.name()};" if is_stderr else ""
         self.log_footer_label.setStyleSheet(stderr_color)
         self.log_footer_label.set_elided_text(f"{chevron}  {timestamp} {first_line}")
+
+    # endregion
 
     def __browse(self):
         # User selects the file with the split images in it.

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -233,6 +233,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         self.split_image_folder_input.setText("No Folder Selected")
 
         # Connecting menu actions
+        self.action_toggle_logs.triggered.connect(self._toggle_log_panel)
         self.action_view_help.triggered.connect(view_help)
         self.action_about.triggered.connect(lambda: open_about(self))
         self.action_about_qt.triggered.connect(about_qt)

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -326,7 +326,6 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         title_spacer.setFixedHeight(0)  # Hide draggable separator
         self.log_dock.setTitleBarWidget(title_spacer)
         self.setStyleSheet("QMainWindow::separator { height: 0px; width: 0px; }")
-        self.log_dock.hide()
         self.log_footer_label.clicked.connect(self._toggle_log_panel)
 
         # Surface anything already logged (e.g. the version/PID line) before connecting live.
@@ -334,16 +333,25 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         for timestamp, text, is_stderr in history:
             self._append_log_line(timestamp, text, is_stderr=is_stderr)
         if history:
-            self._update_log_footer(*history[-1])
+            last_timestamp, last_text, last_is_stderr = history[-1]
+            self._update_log_footer(last_timestamp, last_text, is_stderr=last_is_stderr)
         log_capture.LOG_EMITTER.line_logged.connect(self._on_log_line)
 
-    def _toggle_log_panel(self):
-        show = not self.log_dock.isVisible()
+        # Restore the panel's last expanded/collapsed state.
+        self._set_log_panel_visible(
+            show=cast("bool", user_profile.QT_SETTINGS.value("log_panel_visible", False, type=bool))
+        )
+
+    def _set_log_panel_visible(self, show: bool):  # noqa: FBT001 # boolean value setter, not an arbitrary flag
         self.log_dock.setVisible(show)
         self.resize(self.width(), self.minimumHeight() + (LOG_PANEL_HEIGHT if show else 0))
         self._refresh_log_footer()  # Flip the chevron to match the new state.
 
-    def _append_log_line(self, timestamp: str, text: str, *, is_stderr: bool):
+    def _toggle_log_panel(self):
+        self._set_log_panel_visible(not self.log_dock.isVisible())
+        user_profile.QT_SETTINGS.setValue("log_panel_visible", self.log_dock.isVisible())
+
+    def _append_log_line(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001 # is_stderr is intrinsic line data, not an arbitrary boolean flag
         cursor = self.log_history_view.textCursor()
         cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
         char_format = QtGui.QTextCharFormat()
@@ -355,7 +363,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         scrollbar = self.log_history_view.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 
-    def _update_log_footer(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001
+    def _update_log_footer(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001 # is_stderr is intrinsic line data, not an arbitrary boolean flag
         self._last_footer_entry = (timestamp, text, is_stderr)
         self._refresh_log_footer()
 
@@ -372,8 +380,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         self.log_footer_label.set_elided_text(f"{chevron}  {timestamp} {first_line}")
 
     @QtCore.Slot(str, str, bool)
-    def _on_log_line(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001
-        self._append_log_line(timestamp, text, is_stderr=is_stderr)
+    def _on_log_line(self, timestamp: str, text: str, is_stderr: bool):  # noqa: FBT001 # is_stderr is intrinsic line data, not an arbitrary boolean flag
+        self._append_log_line(timestamp, text, is_stderr)
         self._update_log_footer(timestamp, text, is_stderr)
 
     def __browse(self):

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -117,11 +117,6 @@ _LOG_LOCATION_PREFIX = re.compile(r"^\S+:\d+:\s+")
 """Matches a leading ``path:lineno:`` (e.g. from a warning) to drop it from the footer preview."""
 
 
-def _footer_preview(text: str) -> str:
-    """First line of an (already-relativized) entry; drops a leading ``path:lineno:`` prefix."""
-    return _LOG_LOCATION_PREFIX.sub("", text.split("\n", 1)[0])
-
-
 class AutoSplit(QMainWindow, design.Ui_MainWindow):
     # Parse command line args
     is_auto_controlled = "--auto-controlled" in sys.argv
@@ -151,8 +146,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
     CheckForUpdatesThread: QtCore.QThread | None = None
     SettingsWidget: settings.Ui_SettingsWidget | None = None
 
-    # Last (timestamp, text, is_stderr) shown in the footer, kept so it can be re-rendered.
-    _last_footer_entry: tuple[str, str, bool] | None = None
+    _last_footer_entry: log_capture.LogLine | None = None
+    """Last (timestamp, text, is_stderr) shown in the footer, kept so it can be re-rendered."""
 
     # Window height with the log panel collapsed; captured from the .ui to fix the height per state.
     _collapsed_height = 0
@@ -373,7 +368,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             return
         timestamp, text, is_stderr = self._last_footer_entry
         # Footer is single-line and shows the message directly (no path prefix).
-        first_line = _footer_preview(text)
+        # First line of an (already-relativized) entry; drops a leading ``path:lineno:`` prefix.
+        first_line = _LOG_LOCATION_PREFIX.sub("", text.split("\n", 1)[0])
         # Footer affordances hinting it expands a log panel: a chevron and hover/border styling.
         # Not using isVisible()) as it's incorrect during startup restore, before window is shown
         chevron = "▶" if self.log_dock.isHidden() else "▲"

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -109,10 +109,6 @@ if TYPE_CHECKING:
 
 CHECK_FPS_ITERATIONS = 10
 
-MAIN_CONTENT_HEIGHT = 404
-"""Fixed height of the main (absolutely-laid-out) content, so the expandable log panel grows the
-window downward instead of squashing it. Matches the window's collapsed minimum minus the
-menu and status bars."""
 LOG_PANEL_HEIGHT = 250
 """How tall the expandable log history panel is when shown."""
 LOG_STDERR_COLOR = QtGui.QColor("#c0392b")
@@ -322,19 +318,11 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
 
     def _setup_log_footer(self):
         """Wire up the clickable log footer and the expandable log history panel."""
-        # Pin the main content so the log panel grows the window downward rather than squashing it.
-        self.central_widget.setFixedHeight(MAIN_CONTENT_HEIGHT)
-        # Place the footer label so it fills the status bar and is the click target. A top border
-        # and dropped size grip make the footer read as its own clearly-defined, clickable strip.
+        # The status bar doesn't add() its .ui child, and stretch isn't expressible there.
         self.status_bar.addWidget(self.log_footer_label, 1)
-        self.status_bar.setSizeGripEnabled(False)
         self.status_bar.setContentsMargins(0, 0, 0, 0)  # Let the label's padding define the insets.
-        self.status_bar.setStyleSheet("QStatusBar { border-top: 1px solid palette(mid); }")
-        # Make the dock read as an inline panel: no title bar, hidden until the footer is clicked.
-        title_spacer = QWidget()
-        title_spacer.setFixedHeight(0)  # Hide draggable separator
-        self.log_dock.setTitleBarWidget(title_spacer)
-        self.setStyleSheet("QMainWindow::separator { height: 0px; width: 0px; }")
+        # An empty title bar (collapses to no height) makes the dock read as an inline panel.
+        self.log_dock.setTitleBarWidget(QWidget())
         self.log_footer_label.clicked.connect(self._toggle_log_panel)
 
         # Surface anything already logged (e.g. the version/PID line) before connecting live.
@@ -383,7 +371,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
         # Footer is single-line and shows the message directly (no path prefix).
         first_line = _footer_preview(text)
         # Footer affordances hinting it expands a log panel: a chevron and hover/border styling.
-        chevron = "▲" if self.log_dock.isVisible() else "▶"
+        # Not using isVisible()) as it's incorrect during startup restore, before window is shown
+        chevron = "▶" if self.log_dock.isHidden() else "▲"
         color = LOG_STDERR_COLOR.name() if is_stderr else "palette(text)"
         self.log_footer_label.setStyleSheet(LOG_FOOTER_STYLE.format(color=color))
         self.log_footer_label.set_elided_text(f"{chevron}  {timestamp} {first_line}")

--- a/src/error_messages.py
+++ b/src/error_messages.py
@@ -9,12 +9,24 @@ import traceback
 from types import TracebackType
 from typing import TYPE_CHECKING, NoReturn
 
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 from utils import FROZEN, GITHUB_REPOSITORY
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
+
+# Keep in sync with README.md#DOWNLOAD_AND_OPEN
+WAYLAND_WARNING = """\
+All screen capture method are incompatible with Wayland. Follow this guide to disable it:
+<a href="https://linuxconfig.org/how-to-enable-disable-wayland-on-ubuntu-22-04-desktop"> \
+https://linuxconfig.org/how-to-enable-disable-wayland-on-ubuntu-22-04-desktop</a>"""
+
+CREATE_NEW_ISSUE_MESSAGE = (
+    f"Please create a New Issue at <a href='https://github.com/{GITHUB_REPOSITORY}/issues'>"
+    + f"github.com/{GITHUB_REPOSITORY}/issues</a>, describe what happened, "
+    + "and copy & paste the entire error message below"
+)
 
 
 def __exit_program():
@@ -23,12 +35,16 @@ def __exit_program():
     sys.exit(1)
 
 
-def set_text_message(
+def _set_text_message(
     message: str,
     details: str = "",
     kill_button: str = "",
     accept_button: str = "",
 ):
+    # Also surface the error in the log (console + footer/history) as a single stderr entry.
+    plain_message = QtGui.QTextDocumentFragment.fromHtml(message).toPlainText()
+    sys.stderr.write(f"{plain_message}\n{details}\n" if details else f"{plain_message}\n")
+
     message_box = QtWidgets.QMessageBox()
     message_box.setWindowTitle("Error")
     message_box.setTextFormat(QtCore.Qt.TextFormat.RichText)
@@ -53,66 +69,66 @@ def set_text_message(
 
 
 def split_image_directory():
-    set_text_message("No Split Image Folder is selected.")
+    _set_text_message("No Split Image Folder is selected.")
 
 
 def invalid_directory(directory: str):
-    set_text_message(f"Folder {directory!r} is invalid or does not exist.")
+    _set_text_message(f"Folder {directory!r} is invalid or does not exist.")
 
 
 def no_split_image():
-    set_text_message("Your Split Image Folder should contain at least one Split Image.")
+    _set_text_message("Your Split Image Folder should contain at least one Split Image.")
 
 
 def image_type(image: str):
-    set_text_message(
+    _set_text_message(
         f"{image!r} is not a valid image file, does not exist, "
         + "or the full image file path contains a special character."
     )
 
 
 def region():
-    set_text_message(
+    _set_text_message(
         "No region is selected or the Capture Region window is not open. "
         + "Select a region or load settings while the Capture Region window is open."
     )
 
 
 def split_hotkey():
-    set_text_message("No split hotkey has been set.")
+    _set_text_message("No split hotkey has been set.")
 
 
 def pause_hotkey():
-    set_text_message(
+    _set_text_message(
         "Your Split Image Folder contains an image filename with a pause flag {p}, "
         + "but no pause hotkey is set."
     )
 
 
 def image_validity(image: str = "File"):
-    set_text_message(f"{image} not a valid image file")
+    _set_text_message(f"{image} not a valid image file")
 
 
 def alignment_not_matched():
-    set_text_message("No area in capture region matched reference image. Alignment failed.")
+    _set_text_message("No area in capture region matched reference image. Alignment failed.")
 
 
 def no_keyword_image(keyword: str):
-    set_text_message(
+    _set_text_message(
         f"Your Split Image Folder does not contain an image with the keyword {keyword!r}."
     )
 
 
 def multiple_keyword_images(keyword: str):
-    set_text_message(f"Only one image with the keyword {keyword!r} is allowed.")
+    _set_text_message(f"Only one image with the keyword {keyword!r} is allowed.")
 
 
 def reset_hotkey():
-    set_text_message("Your Split Image Folder contains a Reset Image, but no reset hotkey is set.")
+    _set_text_message("Your Split Image Folder contains a Reset Image, but no reset hotkey is set.")
 
 
 def old_version_settings_file():
-    set_text_message(
+    _set_text_message(
         "Old version settings file detected. "
         + "This version allows settings files in .toml format. "
         + "Starting from v2.0."
@@ -120,48 +136,48 @@ def old_version_settings_file():
 
 
 def invalid_settings():
-    set_text_message("Invalid settings file.")
+    _set_text_message("Invalid settings file.")
 
 
 def invalid_hotkey(hotkey_name: str):
-    set_text_message(f"Invalid hotkey {hotkey_name!r}")
+    _set_text_message(f"Invalid hotkey {hotkey_name!r}")
 
 
 def no_settings_file_on_open():
-    set_text_message(
+    _set_text_message(
         "No settings file found. "
         + "One can be loaded on open if placed in the same folder as the AutoSplit executable."
     )
 
 
 def too_many_settings_files_on_open():
-    set_text_message(
+    _set_text_message(
         "Too many settings files found. "
         + "Only one can be loaded on open if placed in the same folder as the AutoSplit executable."
     )
 
 
 def check_for_updates():
-    set_text_message(
+    _set_text_message(
         "An error occurred while attempting to check for updates. Please check your connection."
     )
 
 
 def load_start_image():
-    set_text_message(
+    _set_text_message(
         "Start Image found, but cannot be loaded unless Start hotkey is set. "
         + "Please set the hotkey, and then click the Reload Start Image button."
     )
 
 
 def stdin_lost():
-    set_text_message(
+    _set_text_message(
         "stdin not supported or lost, external control like LiveSplit integration will not work."
     )
 
 
 def already_open():
-    set_text_message(
+    _set_text_message(
         "An instance of AutoSplit is already running."
         + "<br/>Are you sure you want to open a another one?",
         "",
@@ -171,7 +187,7 @@ def already_open():
 
 
 def linux_groups():
-    set_text_message(
+    _set_text_message(
         "Linux users must ensure they are in the 'tty' and 'input' groups "
         + "and have write access to '/dev/uinput'. You can run the following commands to do so:",
         # Keep in sync with README.md and scripts/install.ps1
@@ -188,22 +204,15 @@ loginctl terminate-user $USER""",
 
 
 def linux_uinput():
-    set_text_message(
+    _set_text_message(
         "Failed to create a device file using `uinput` module. "
         + "This can happen when running Linux under WSL. "
         + "Keyboard events have been disabled."
     )
 
 
-# Keep in sync with README.md#DOWNLOAD_AND_OPEN
-WAYLAND_WARNING = """\
-All screen capture method are incompatible with Wayland. Follow this guide to disable it:
-<a href="https://linuxconfig.org/how-to-enable-disable-wayland-on-ubuntu-22-04-desktop"> \
-https://linuxconfig.org/how-to-enable-disable-wayland-on-ubuntu-22-04-desktop</a>"""
-
-
 def linux_wayland():
-    set_text_message(WAYLAND_WARNING)
+    _set_text_message(WAYLAND_WARNING)
 
 
 def exception_traceback(exception: BaseException, message: str = ""):
@@ -213,18 +222,39 @@ def exception_traceback(exception: BaseException, message: str = ""):
             + "however, there is no guarantee it will keep working properly. "
             + CREATE_NEW_ISSUE_MESSAGE
         )
-    set_text_message(
+    _set_text_message(
         message,
         "\n".join(traceback.format_exception(None, exception, exception.__traceback__)),
         "Close AutoSplit",
     )
 
 
-CREATE_NEW_ISSUE_MESSAGE = (
-    f"Please create a New Issue at <a href='https://github.com/{GITHUB_REPOSITORY}/issues'>"
-    + f"github.com/{GITHUB_REPOSITORY}/issues</a>, describe what happened, "
-    + "and copy & paste the entire error message below"
-)
+def tesseract_missing(ocr_split_file_path: str):
+    _set_text_message(
+        f"{ocr_split_file_path!r} is an Optical Character Recognition split file "
+        + "but tesseract couldn't be found."
+        + f'\nPlease read <a href="https://github.com/{GITHUB_REPOSITORY}#install-tesseract">'
+        + f"github.com/{GITHUB_REPOSITORY}#install-tesseract</a> for installation instructions."
+    )
+
+
+def ocr_missing_key(ocr_split_file_path: str, missing_key: str):
+    _set_text_message(f"{ocr_split_file_path!r} is missing an entry for {missing_key!r}")
+
+
+def wrong_ocr_values(ocr_split_file_path: str):
+    _set_text_message(
+        f"{ocr_split_file_path!r} has invalid values."
+        + "\nPlease make sure that `left &lt; right` and `top &lt; bottom`. "
+        + "Also check for negative values in the 'methods' or 'fps_limit' settings"
+    )
+
+
+def invalid_filename_delimiters(filename: str, delimiters: str):
+    _set_text_message(
+        f"Split '{filename}' contains invalid parameters. "
+        + f"'{delimiters}' must not appear more than once."
+    )
 
 
 def make_excepthook(autosplit: AutoSplit):
@@ -258,31 +288,3 @@ def handle_top_level_exceptions(exception: Exception) -> NoReturn:
     else:
         traceback.print_exception(type(exception), exception, exception.__traceback__)
     sys.exit(1)
-
-
-def tesseract_missing(ocr_split_file_path: str):
-    set_text_message(
-        f"{ocr_split_file_path!r} is an Optical Character Recognition split file "
-        + "but tesseract couldn't be found."
-        + f'\nPlease read <a href="https://github.com/{GITHUB_REPOSITORY}#install-tesseract">'
-        + f"github.com/{GITHUB_REPOSITORY}#install-tesseract</a> for installation instructions."
-    )
-
-
-def ocr_missing_key(ocr_split_file_path: str, missing_key: str):
-    set_text_message(f"{ocr_split_file_path!r} is missing an entry for {missing_key!r}")
-
-
-def wrong_ocr_values(ocr_split_file_path: str):
-    set_text_message(
-        f"{ocr_split_file_path!r} has invalid values."
-        + "\nPlease make sure that `left &lt; right` and `top &lt; bottom`. "
-        + "Also check for negative values in the 'methods' or 'fps_limit' settings"
-    )
-
-
-def invalid_filename_delimiters(filename: str, delimiters: str):
-    set_text_message(
-        f"Split '{filename}' contains invalid parameters. "
-        + f"'{delimiters}' must not appear more than once."
-    )

--- a/src/error_messages.py
+++ b/src/error_messages.py
@@ -41,7 +41,7 @@ def _set_text_message(
     kill_button: str = "",
     accept_button: str = "",
 ):
-    # Also surface the error in the log (console + footer/history) as a single stderr entry.
+    # Also surface the error message in the logs
     plain_message = QtGui.QTextDocumentFragment.fromHtml(message).toPlainText()
     sys.stderr.write(f"{plain_message}\n{details}\n" if details else f"{plain_message}\n")
 

--- a/src/log_capture.py
+++ b/src/log_capture.py
@@ -1,0 +1,159 @@
+"""
+Capture everything written to the console (``print``, ``warnings``, ``logging``'s last-resort
+handler, uncaught tracebacks) without suppressing it, and re-broadcast each completed line as a Qt
+signal so the GUI can surface it in the log footer.
+
+The real ``sys.stdout`` / ``sys.stderr`` are *teed*, never replaced: writes still reach the original
+streams byte-for-byte (this keeps the ``--auto-controlled`` LiveSplit stdout protocol intact), and a
+copy of each line is emitted on top.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from collections import deque
+from datetime import datetime
+from typing import TextIO, cast, override
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+LOG_HISTORY_MAX_LINES = 5000
+"""A line is more than enough context for a footer, but keep a generous scrollback for the panel."""
+TIMESTAMP_FORMAT = "%H:%M:%S.%f"
+"""Time-only (no date) timestamp prefixed to each displayed log line. `%f` is microseconds; the last
+3 digits are trimmed off at format time to leave milliseconds."""
+
+EXCLUDED_SUBSTRINGS = (
+    # The `keyboard` library prints this on Linux when AutoSplit isn't in the `input` group.
+    # AutoSplit already surfaces this properly via `error_messages.linux_groups()`.
+    "You must be in the 'input' group to access global events",
+)
+"""Substrings of known-benign dependency messages to hide from the footer/history because they would
+mislead users. These are still written to the real console: only the in-app log is filtered"""
+
+LogLine = tuple[str, str, bool]
+"""A logged line: ``(timestamp, text, is_stderr)``. ``is_stderr`` marks warnings/errors."""
+
+
+class LogEmitter(QtCore.QObject):
+    """Thread-safe fan-out of logged lines to the GUI, with a bounded scrollback buffer."""
+
+    line_logged = QtCore.Signal(str, str, bool)
+    """Emitted once per completed line: ``(timestamp, text, is_stderr)``."""
+
+    def __init__(self):
+        super().__init__()
+        self._lock = threading.Lock()
+        self._history: deque[LogLine] = deque(maxlen=LOG_HISTORY_MAX_LINES)
+
+    def emit_line(self, text: str, *, is_stderr: bool):
+        # The console already received this (the tee writes before emitting); only the in-app log
+        # filters out blank lines (e.g. a lone "\n" write) and known-benign noise.
+        if not text or any(excluded in text for excluded in EXCLUDED_SUBSTRINGS):
+            return
+        # Stamp at capture time (on the writing thread) so the time reflects when it was logged.
+        # Naive local wall-clock time is intentional for a log footer (DTZ005: no tz wanted).
+        timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)[:-3] + ":"  # noqa: DTZ005
+        with self._lock:
+            self._history.append((timestamp, text, is_stderr))
+        # Queued across threads thanks to Qt's auto-connection: safe to call from any thread.
+        self.line_logged.emit(timestamp, text, is_stderr)
+
+    def history(self) -> list[LogLine]:
+        """Snapshot of the lines logged so far, oldest first."""
+        with self._lock:
+            return list(self._history)
+
+
+LOG_EMITTER = LogEmitter()
+"""Process-wide singleton. The GUI connects to this; the tee streams write to it."""
+
+
+class _TeeStream:
+    """
+    A text stream that forwards to a real stream (if any) and mirrors completed output to the
+    emitter. ``real`` may be ``None`` in frozen ``--noconsole`` builds, in which case there is no
+    console to write to but the footer still receives the output.
+
+    A single ``write`` is treated as one log entry, even when it spans several lines (e.g. a
+    multi-line warning), so it gets a single timestamp and renders as one multi-line block.
+    Separate ``write`` calls (e.g. successive ``print`` calls) stay separate entries.
+    """
+
+    def __init__(self, real: TextIO | None, emitter: LogEmitter, *, is_stderr: bool):
+        self._real = real
+        self._emitter = emitter
+        self._is_stderr = is_stderr
+        self._partial = ""
+
+    def write(self, text: str) -> int:
+        if self._real is not None:
+            self._real.write(text)
+        self._partial += text
+        # Emit everything up to the last newline as one entry (keeping internal newlines), and hold
+        # any trailing partial line until it's completed by a later write.
+        newline_index = self._partial.rfind("\n")
+        if newline_index != -1:
+            self._emitter.emit_line(self._partial[:newline_index], is_stderr=self._is_stderr)
+            self._partial = self._partial[newline_index + 1 :]
+        return len(text)
+
+    def flush(self):
+        if self._real is not None:
+            self._real.flush()
+
+    def __getattr__(self, name: str) -> object:
+        # Delegate everything else (encoding, fileno, isatty, errors, ...) to the real stream so the
+        # tee is indistinguishable from it. `_real` is always set in __init__, so no recursion.
+        real = self.__dict__["_real"]
+        if real is None:
+            raise AttributeError(name)
+        return getattr(real, name)
+
+
+def install():
+    """
+    Wrap ``sys.stdout`` and ``sys.stderr`` so console output is mirrored to `LOG_EMITTER`.
+
+    Call once, as early as possible, so startup output is captured.
+    """
+    sys.stdout = cast("TextIO", _TeeStream(sys.stdout, LOG_EMITTER, is_stderr=False))
+    sys.stderr = cast("TextIO", _TeeStream(sys.stderr, LOG_EMITTER, is_stderr=True))
+
+
+class ClickableLabel(QtWidgets.QLabel):
+    """
+    A `QLabel` that emits `clicked` when pressed and right-elides its text to fit its current width.
+    Used as the log footer; promoted from `QLabel` in ``design.ui``.
+    """
+
+    clicked = QtCore.Signal()
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        self._full_text = ""
+        self.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
+
+    def set_elided_text(self, text: str):
+        self._full_text = text
+        self._update_elision()
+
+    def _update_elision(self):
+        metrics = self.fontMetrics()
+        # Elide to the content rect (excludes padding) so left and right padding are kept.
+        width = self.contentsRect().width()
+        super().setText(
+            metrics.elidedText(self._full_text, QtCore.Qt.TextElideMode.ElideRight, width)
+        )
+
+    @override
+    def resizeEvent(self, event: QtGui.QResizeEvent):
+        # The label re-elides in its own resizeEvent, when its width is already up to date.
+        super().resizeEvent(event)
+        self._update_elision()
+
+    @override
+    def mousePressEvent(self, ev: QtGui.QMouseEvent):
+        self.clicked.emit()
+        super().mousePressEvent(ev)

--- a/src/log_capture.py
+++ b/src/log_capture.py
@@ -10,6 +10,7 @@ copy of each line is emitted on top.
 
 from __future__ import annotations
 
+import os
 import sys
 import threading
 from collections import deque
@@ -35,6 +36,9 @@ mislead users. These are still written to the real console: only the in-app log 
 LogLine = tuple[str, str, bool]
 """A logged line: ``(timestamp, text, is_stderr)``. ``is_stderr`` marks warnings/errors."""
 
+_WORKING_DIR_PREFIX = f"{os.getcwd()}{os.sep}"
+"""Absolute prefix stripped from captured paths to show them relative to the working dir."""
+
 
 class LogEmitter(QtCore.QObject):
     """Thread-safe fan-out of logged lines to the GUI, with a bounded scrollback buffer."""
@@ -52,6 +56,8 @@ class LogEmitter(QtCore.QObject):
         # filters out blank lines (e.g. a lone "\n" write) and known-benign noise.
         if not text or any(excluded in text for excluded in EXCLUDED_SUBSTRINGS):
             return
+        # Store paths relative to the working dir (the console already got the absolute ones).
+        text = text.replace(_WORKING_DIR_PREFIX, "")
         # Stamp at capture time (on the writing thread) so the time reflects when it was logged.
         # Naive local wall-clock time is intentional for a log footer (DTZ005: no tz wanted).
         timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)[:-3] + ":"  # noqa: DTZ005

--- a/src/log_capture.py
+++ b/src/log_capture.py
@@ -4,7 +4,7 @@ handler, uncaught tracebacks) without suppressing it, and re-broadcast each comp
 signal so the GUI can surface it in the log footer.
 
 The real `sys.stdout` / `sys.stderr` are *teed*, never replaced: writes still reach the original
-streams byte-for-byte (this keeps the `--auto-controlled` LiveSplit stdout protocol intact), and a
+streams as-is (keeping `--auto-controlled` stdout protocol intact), and a formatted
 copy of each line is emitted on top.
 """
 

--- a/src/log_capture.py
+++ b/src/log_capture.py
@@ -1,10 +1,10 @@
 """
-Capture everything written to the console (``print``, ``warnings``, ``logging``'s last-resort
+Capture everything written to the console (`print`, `warnings`, `logging`'s last-resort
 handler, uncaught tracebacks) without suppressing it, and re-broadcast each completed line as a Qt
 signal so the GUI can surface it in the log footer.
 
-The real ``sys.stdout`` / ``sys.stderr`` are *teed*, never replaced: writes still reach the original
-streams byte-for-byte (this keeps the ``--auto-controlled`` LiveSplit stdout protocol intact), and a
+The real `sys.stdout` / `sys.stderr` are *teed*, never replaced: writes still reach the original
+streams byte-for-byte (this keeps the `--auto-controlled` LiveSplit stdout protocol intact), and a
 copy of each line is emitted on top.
 """
 
@@ -19,32 +19,27 @@ from typing import TextIO, cast, override
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-LOG_HISTORY_MAX_LINES = 5000
-"""A line is more than enough context for a footer, but keep a generous scrollback for the panel."""
+LOG_HISTORY_MAX_LINES = 256 * 2**4
+"""Arbitrary scrollback cap. Memory-bounded, but more than enough for a log session."""
 TIMESTAMP_FORMAT = "%H:%M:%S.%f"
 """Time-only (no date) timestamp prefixed to each displayed log line. `%f` is microseconds; the last
 3 digits are trimmed off at format time to leave milliseconds."""
 
 EXCLUDED_SUBSTRINGS = (
-    # The `keyboard` library prints this on Linux when AutoSplit isn't in the `input` group.
-    # AutoSplit already surfaces this properly via `error_messages.linux_groups()`.
+    # False-positive: `keyboard` prints this on first import even when the user IS in the `input`
+    # group. A proper check is already done and shown through `error_messages.linux_groups()`.
     "You must be in the 'input' group to access global events",
 )
-"""Substrings of known-benign dependency messages to hide from the footer/history because they would
-mislead users. These are still written to the real console: only the in-app log is filtered"""
+"""Substrings of entries to hide from the log history because they would mislead users.
+These are still written to the real console: only the in-app log is filtered"""
 
 LogLine = tuple[str, str, bool]
-"""A logged line: ``(timestamp, text, is_stderr)``. ``is_stderr`` marks warnings/errors."""
-
-_WORKING_DIR_PREFIX = f"{os.getcwd()}{os.sep}"
-"""Absolute prefix stripped from captured paths to show them relative to the working dir."""
+"""A logged line: `(timestamp, text, is_stderr)`. `is_stderr` marks warnings/errors."""
 
 
 class LogEmitter(QtCore.QObject):
     """Thread-safe fan-out of logged lines to the GUI, with a bounded scrollback buffer."""
 
-    # `Signal(LogLine)` can't be used: PySide rejects the subscripted `tuple[...]` alias and
-    # silently registers a zero-arg signal, so the payload type is documented here instead.
     line_logged = QtCore.Signal(tuple)
     """Emitted once per completed line, carrying a `LogLine`: `(timestamp, text, is_stderr)`."""
 
@@ -58,15 +53,14 @@ class LogEmitter(QtCore.QObject):
         # filters out blank lines (e.g. a lone "\n" write) and known-benign noise.
         if not text or any(excluded in text for excluded in EXCLUDED_SUBSTRINGS):
             return
-        # Store paths relative to the working dir (the console already got the absolute ones).
-        text = text.replace(_WORKING_DIR_PREFIX, "")
+        # Store paths relative to the working dir by stripping the working dir path
+        text = text.replace(f"{os.getcwd()}{os.sep}", "")
         # Stamp at capture time (on the writing thread) so the time reflects when it was logged.
         # Naive local wall-clock time is intentional for a log footer (DTZ005: no tz wanted).
         timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)[:-3] + ":"  # noqa: DTZ005
         log_line: LogLine = (timestamp, text, is_stderr)
         with self._lock:
             self._history.append(log_line)
-        # Queued across threads thanks to Qt's auto-connection: safe to call from any thread.
         self.line_logged.emit(log_line)
 
     def history(self):
@@ -82,12 +76,12 @@ LOG_EMITTER = LogEmitter()
 class _TeeStream:
     """
     A text stream that forwards to a real stream (if any) and mirrors completed output to the
-    emitter. ``real`` may be ``None`` in frozen ``--noconsole`` builds, in which case there is no
+    emitter. `real` may be `None` in frozen `--noconsole` builds, in which case there is no
     console to write to but the footer still receives the output.
 
-    A single ``write`` is treated as one log entry, even when it spans several lines (e.g. a
+    A single `write` is treated as one log entry, even when it spans several lines (e.g. a
     multi-line warning), so it gets a single timestamp and renders as one multi-line block.
-    Separate ``write`` calls (e.g. successive ``print`` calls) stay separate entries.
+    Separate `write` calls (e.g. successive `print` calls) stay separate entries.
     """
 
     def __init__(self, real: TextIO | None, emitter: LogEmitter, *, is_stderr: bool):
@@ -123,7 +117,7 @@ class _TeeStream:
 
 def install():
     """
-    Wrap ``sys.stdout`` and ``sys.stderr`` so console output is mirrored to `LOG_EMITTER`.
+    Wrap `sys.stdout` and `sys.stderr` so console output is mirrored to `LOG_EMITTER`.
 
     Call once, as early as possible, so startup output is captured.
     """
@@ -134,7 +128,7 @@ def install():
 class ClickableLabel(QtWidgets.QLabel):
     """
     A `QLabel` that emits `clicked` when pressed and right-elides its text to fit its current width.
-    Used as the log footer; promoted from `QLabel` in ``design.ui``.
+    Used as the log footer; promoted from `QLabel` in `design.ui`.
     """
 
     clicked = QtCore.Signal()

--- a/src/log_capture.py
+++ b/src/log_capture.py
@@ -43,8 +43,10 @@ _WORKING_DIR_PREFIX = f"{os.getcwd()}{os.sep}"
 class LogEmitter(QtCore.QObject):
     """Thread-safe fan-out of logged lines to the GUI, with a bounded scrollback buffer."""
 
-    line_logged = QtCore.Signal(str, str, bool)
-    """Emitted once per completed line: ``(timestamp, text, is_stderr)``."""
+    # `Signal(LogLine)` can't be used: PySide rejects the subscripted `tuple[...]` alias and
+    # silently registers a zero-arg signal, so the payload type is documented here instead.
+    line_logged = QtCore.Signal(tuple)
+    """Emitted once per completed line, carrying a `LogLine`: `(timestamp, text, is_stderr)`."""
 
     def __init__(self):
         super().__init__()
@@ -61,12 +63,13 @@ class LogEmitter(QtCore.QObject):
         # Stamp at capture time (on the writing thread) so the time reflects when it was logged.
         # Naive local wall-clock time is intentional for a log footer (DTZ005: no tz wanted).
         timestamp = datetime.now().strftime(TIMESTAMP_FORMAT)[:-3] + ":"  # noqa: DTZ005
+        log_line: LogLine = (timestamp, text, is_stderr)
         with self._lock:
-            self._history.append((timestamp, text, is_stderr))
+            self._history.append(log_line)
         # Queued across threads thanks to Qt's auto-connection: safe to call from any thread.
-        self.line_logged.emit(timestamp, text, is_stderr)
+        self.line_logged.emit(log_line)
 
-    def history(self) -> list[LogLine]:
+    def history(self):
         """Snapshot of the lines logged so far, oldest first."""
         with self._lock:
             return list(self._history)
@@ -93,7 +96,7 @@ class _TeeStream:
         self._is_stderr = is_stderr
         self._partial = ""
 
-    def write(self, text: str) -> int:
+    def write(self, text: str):
         if self._real is not None:
             self._real.write(text)
         self._partial += text
@@ -109,7 +112,7 @@ class _TeeStream:
         if self._real is not None:
             self._real.flush()
 
-    def __getattr__(self, name: str) -> object:
+    def __getattr__(self, name: str):
         # Delegate everything else (encoding, fileno, isatty, errors, ...) to the real stream so the
         # tee is indistinguishable from it. `_real` is always set in __init__, so no recursion.
         real = self.__dict__["_real"]


### PR DESCRIPTION
Closes https://github.com/Toufool/AutoSplit/issues/262

- Added a clickable/expandable footer that shows the last log
- Expands to a ~10 lines high full log
- Additional Python warning logs we didn't even have before in console mode
- Added toggle menu item and shortcut
- Persist toggle state between app sessions
- stderr and python warnings are automatically colored red

Next steps would be:
- Adding useful logs from the app itself / search for previous fixes where custom logs would've been useful
- Logging to file

Which would be relate to https://github.com/Toufool/AutoSplit/issues/12